### PR TITLE
Add hostRequirements gpus description

### DIFF
--- a/docs/specs/devcontainerjson-reference.md
+++ b/docs/specs/devcontainerjson-reference.md
@@ -79,6 +79,7 @@ While `devcontainer.json` does not focus on hardware or VM provisioning, it can 
 | Property | Type | Description |
 |----------|------|-------------|
 | `hostRequirements.cpus` | integer | Indicates the minimum required number of CPUs / virtual CPUs / cores. For example: `"hostRequirements": {"cpus": 2}` |
+| `hostRequirements.gpus` | integer | Indicates the minimum required number of GPU cores. For example: `"hostRequirements": {"cpus": 2}` |
 | `hostRequirements.memory` | string |  A string indicating minimum memory requirements with a `tb`, `gb`, `mb`, or `kb` suffix. For example, `"hostRequirements": {"memory": "4gb"}` |
 | `hostRequirements.storage` | string | A string indicating minimum storage requirements with a `tb`, `gb`, `mb`, or `kb` suffix. For example, `"hostRequirements": {"storage": "32gb"}` |
 

--- a/docs/specs/devcontainerjson-reference.md
+++ b/docs/specs/devcontainerjson-reference.md
@@ -79,7 +79,7 @@ While `devcontainer.json` does not focus on hardware or VM provisioning, it can 
 | Property | Type | Description |
 |----------|------|-------------|
 | `hostRequirements.cpus` | integer | Indicates the minimum required number of CPUs / virtual CPUs / cores. For example: `"hostRequirements": {"cpus": 2}` |
-| `hostRequirements.gpus` | integer | Indicates the minimum required number of GPU cores. For example: `"hostRequirements": {"cpus": 2}` |
+| `hostRequirements.gpus` | integer | Indicates the minimum required number of GPU cores. For example: `"hostRequirements": {"gpus": 2}` |
 | `hostRequirements.memory` | string |  A string indicating minimum memory requirements with a `tb`, `gb`, `mb`, or `kb` suffix. For example, `"hostRequirements": {"memory": "4gb"}` |
 | `hostRequirements.storage` | string | A string indicating minimum storage requirements with a `tb`, `gb`, `mb`, or `kb` suffix. For example, `"hostRequirements": {"storage": "32gb"}` |
 


### PR DESCRIPTION
Add description for new hostRequirements gpus option, added by this PR: https://github.com/github/github/pull/222154.

Note: That second diff at the end of the file doesn't actually show up as anything in the file preview, I'm not sure why it's showing up like that.