### PR TITLE
[Proposal] 'Features' Distribution Specification

### DIFF
--- a/proposals/devcontainer-features-distribution.md
+++ b/proposals/devcontainer-features-distribution.md
@@ -5,7 +5,7 @@ This specification defines a pattern where community members and organizations c
 Goals include:
 
 - For community authors, a "self-served" mechanism for dev container feature publishing.
-- For community members, a largely self-served mechanism for marking features as "discoverable" by [supporting tools](../docs/specs/supporting-tools.md).
+- For community members, the ability to publish will allow  [supporting tools](../docs/specs/supporting-tools.md) to implement their own discovery mechanisms.
 - For users, ease of discoverability of features via [supporting tools](../docs/specs/supporting-tools.md).
 - For users, the abilty to validate the origin of the asset and its integrity when compared to previous pulls. 
 - For users, the ability for a user to pin to a particular version (absolute, or semantic version) of a feature to allow consistent, repeatable environments.
@@ -14,7 +14,7 @@ Goals include:
 
 Features source code is stored in a git repository.
 
-For ease of authorship and maintenance, [1..n] features can share a single git repository.  This set of features is referred to as a collection, and will share the same [`devcontainer-collection.json`](#devcontainer-collection.json) file and 'namespace' (eg. `owner/repo`).
+For ease of authorship and maintenance, [1..n] features can share a single git repository.  This set of features is referred to as a collection, and will share the same [`devcontainer-collection.json`](#devcontainer-collection.json) file and 'namespace' (eg. `<owner>/<repo>`).
 
 Source code for the set follows the example file structure below:
 
@@ -44,7 +44,7 @@ Source code for the set follows the example file structure below:
 ├── ...
 ```
 
-Where `src` is a directory containing a sub-folder with the name of the feature (e.g. `dotnet` or `go`) with at least a file named `devcontainer-feature.json` that contains the feature metadata. Each feature sub-directory also contains an `install.sh` script that implementing tools will use to install the feature.  Each sub-directory should be named such that it matches the `id` field of the `devcontainer-feature.json`.  Other files can also be included in the sub-directory, and will be packaged along side the two required files.
+Where `src` is a directory containing a sub-folder with the name of the feature (e.g. `src/dotnet` or `src/go`) with at least a file named `devcontainer-feature.json` that contains the feature metadata, and an `install.sh` script that implementing tools will use as the entrypoint to install the feature.  Each sub-directory should be named such that it matches the `id` field of the `devcontainer-feature.json`.  Other files can also be included in the feature's sub-directory, and will be packaged along side the two required files.  Any files that are not part of the feature's sub-directory (e.g. outside of `src/dotnet`) will not be packaged.
 
 Optionally, a mirrored `test` directory can be included with an accompanying `test.sh` script.  Implementing tools may use this to run tests against the given feature.
 
@@ -127,5 +127,5 @@ oras push ${REGISTRY}/${NAMESPACE}:latest \
 
 ### Directly Reference Tarball
 
-A feature can be referenced directly in a `devcontainer.json` file by an HTTP URI that points to the tarball from the [package step](#packaging).
+A feature can be referenced directly in a user's [`devcontainer.json`](/docs/specs/devcontainer-reference.md#devcontainerjson) file by an HTTP URI that points to the tarball from the [package step](#packaging).
 

--- a/proposals/devcontainer-features-distribution.md
+++ b/proposals/devcontainer-features-distribution.md
@@ -1,0 +1,185 @@
+# Community Contribution and Discovery of Dev Container Features
+
+This specification defines a pattern where community members and organizations can author and self-publish [dev container 'features'](./devcontainer-features.md). 
+
+Goals include:
+
+- For community authors, a "self-served" mechanism for dev container feature publishing.
+- For community members, a largely self-served mechanism for marking features as "discoverable" by [supporting tools](../docs/specs/supporting-tools.md).
+- For users, ease of discoverability of features via [supporting tools](../docs/specs/supporting-tools.md).
+- For users, the abilty to validate the origin of the asset and its integrity when compared to previous pulls. 
+- For users, the ability for a user to pin to a particular version (absolute, or semantic version) of a feature to allow consistent, repeatable environments.
+
+## Source Code
+
+Features source code is stored in a git repository.
+
+For ease of authorship and maintenance, [1..n] features can share a single git repository.  This set of features is referred to as feature collections, and will share the same [`devcontainer-collection.json`](#devcontainer-collection.json) file and namespace.
+
+Source code for the set follows the example file structure below:
+
+```
+.
+├── README.md
+├── src
+│   ├── dotnet
+│   │   ├── devcontainer-feature.json
+│   │   ├── install.sh
+│   │   └── ...
+|   ├
+│   ├── go
+│   │   ├── devcontainer-feature.json
+│   │   └── install.sh
+|   ├── ...
+│   │   ├── devcontainer-feature.json
+│   │   └── install.sh
+├── test
+│   ├── dotnet
+│   │   ├── devcontainer-feature.json
+│   │   └── ...
+│   └── go
+│   |   └── test.sh
+|   ├── ...
+│   │   └── test.sh
+├── ...
+```
+
+Where `src` is a directory containing a sub-folder with the name of the feature (e.g. `dotnet` or `go`) with at least a file named `devcontainer-feature.json` that contains the feature metadata. Each feature sub-directory also contains an `install.sh` script that implementing tools will use to install the feature.  Each sub-directory should be named such that it matches the `id` field of the `devcontainer-feature.json`.  Other files can also be included in the sub-directory, and will be packaged along side the two required files.
+
+Optionally, a mirrored `test` directory can be included with an accompanying `test.sh` script.  Implementing tools may use this to run tests against the given feature.
+
+## Versioning
+
+Each feature is individually [versioned according to the semver specification](https://semver.org/).  The `version` property in the respective `devcontainer-feature.json` file is parsed to determine if the feature should be republished.
+
+Tooling that handles publishing features will not republish features if that exact version has already been published; however, tooling must republish major and minor versions in accordance with the semver specification.
+
+## Packaging
+
+Features are distributed as tarballs.  The tarball contains the entire contents of the feature sub-directory, including the `devcontainer-feature.json`, `install.sh`, and any other files in the directory.
+
+The tarball is named `devcontainer-feature-<id>.tgz`, where `<id>` is the feature's `id` field.
+
+A reference implementation for packaging and distributing features is provided as a GitHub Action (https://github.com/devcontainers/action).
+
+
+### devcontainer-collection.json
+
+The `devcontainer-collection.json` is an auto-generated metadata file.
+
+| Property | Type | Description |
+| :--- | :--- | :--- |
+| sourceInformation | object | Metadata from the implementing packaging tool. |
+| features | array | The list of features that are contained in this collection.|
+<!-- | templates | array | The list of templates contained in this collection. Same information as the metadata file for the definition.| -->
+
+
+Each features's `devcontainer-feature.json` metadata file is appended into the `features` top-level array.
+
+## Distribution
+
+There are several supported ways to distribute features.  With appropriate authentication a user references a distributed feature in a `devcontainer.json` as defined in ['referencing a feature'](./devcontainer-features.md#Referencing-a-feature).
+
+### OCI Registry
+
+An OCI registry that implements the [OCI Artifact Distribution Specification](https://github.com/opencontainers/distribution-spec) serves as the primary distribution mechanism for features.
+
+Each packaged feature is pushed to the registry following the naming convention `<registry>/<namespace>/<id>[:version]`, where version is the major, minor, and patch version of the feature, according to the semver specification.
+
+A custom media type `application/vnd.devcontainers` and `application/vnd.devcontainers.layer.v1+tar` are used as demonstrated below.
+
+For example, the `go` feature in the `devcontainers/features` namespace at version `1.2.3` would be pushed to the ghcr.io OCI registry.
+```bash
+# ghcr.io/devcontainers/features/go:1 
+REGISTRY=ghcr.io
+NAMESPACE=devcontainers/features
+FEATURE=go
+
+ARTIFACT_PATH=devcontainer-feature-go.tgz
+
+for VERSION in 1  1.2  1.2.3  latest
+do
+    oras push ${REGISTRY}/${NAMESPACE}/${FEATURE}:${VERSION} \
+            --manifest-config /dev/null:application/vnd.devcontainers \
+                             ./${ARTIFACT_PATH}:application/vnd.devcontainers.layer.v1+tar`;
+done
+
+```
+
+`Namespace` is the globally identifiable name for the collection of features. (eg: `owner/repo` for the source code's git repository).
+
+The auto-generated `devcontainer-collection.json` is pushed to the registry with the same `namespace` as above and no accompanying `feature` name. The collection file is always tagged as `latest`.
+
+```bash
+# ghcr.io/devcontainers/features
+REGISTRY=ghcr.io
+NAMESPACE=devcontainers/features
+
+oras push ${REGISTRY}/${NAMESPACE}:latest \
+        --manifest-config /dev/null:application/vnd.devcontainers \
+                            ./devcontainer-collection.json.:application/vnd.devcontainers.layer.v1+json`;
+```
+
+### Directly reference tarball
+
+A feature can be referenced directly in a `devcontainer.json` file by an HTTP URI that points to the tarball from the [package step](#packaging).
+
+<!-- 
+## Github Topics
+
+A set of discoverable dev container-related repos can be achieved with the use of [GitHub Topics](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/classifying-your-repository-with-topics). You may explore repos that GitHub has automatically considered part of the [devcontainers](https://github.com/topics/devcontainers) topic. If you'd like your template or feature repo to be easily discoverable to the community, you may add the **devcontainers-templates** and/or **devcontainers-features** topic. You may read more on how to do this in the [topics guide](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/classifying-your-repository-with-topics).
+
+Any UI application can leverage this search to provide a list of repositories that contain features or templates and present them to their users. The application would query the latest release of repos within the list and obtain their details to show them to the users.
+
+An implementation of the spec can also use other mechanisms to speed up or improve the user experience while searching.
+
+At the same time, it should include a way for users to directly reference a repository containing the features or templates they want to use.
+
+## Releases
+
+As a distribution and storage mechanism, we propose using GitHub releases. The releases would contain compressed files with the source code of the feature or template. Included with the release the corresponding metadata file would be either **devcontainer-feature.json**, **devcontainer-template.json** or **devcontainer-collection.json**.
+
+## Collections
+
+Features and/or templates can be distributed both as a single unit or as a **collection** of them. In case they are released as a collection, the release should include a **devcontainer-collection.json** file that groups the information of each feature or template contained.
+
+| Property | Type | Description |
+| :--- | :--- | :--- |
+| publisher | string | The organization/user that publishes this group of templates/features. Must match with the repository user in GitHub.|
+| repository | string | The repository where this collection is contained.|
+| version | string | Version information of this collection list.|
+| features | array | The list of features that are contained in this collection. Same information as the metadata file for the feature.|
+| templates | array | The list of templates contained in this collection. Same information as the metadata file for the definition.|
+
+It's important to note the following about collections:
+
+- It is recomended that the **devcontainer-collection.json** file is created automatically as part of the release process.
+- The compressed release file should contain all the folders of the features/templates included in it.
+- The names of the folders should coincide with the id of the feature/template itself.
+- When a **devcontainer-collection.json** file is created, the Id's of the features/templatescontained in it should get the name of the collection added to them to aid in the search for the source. For example, in repository 'https://github.com/community/features' for a collection called 'collection', the resulting id would be 'community/features/collection/myFeature'.
+
+## Templates specifics
+
+By their nature, templates are single use since they are just a group of files that are copied over to an end user's repository and used to kickstart a **dev container** configuration.
+
+Because of this, the implementing application needs to ensure that the user is able to inspect all files included in the template and that no code is executed automatically until a specific action by a user demands it. 
+
+## Features specifics
+
+Since features contain code that can be executed multiple times by different users, the security of the contents is important, and for this we propose:
+
+- Any application that implements the [Dev container spec](../docs/specs/devcontainer-reference.md) must provide a way for the user to add a feature to their `devcontainer.json` file in a way that the code can be inspected before it executes the first time.
+- This action should create a **devcontainer.lock** file next to the main `devcontainer.json` file that contains the checksums of the particular release referenced.
+- Users can commit this file to their repository so that the application can berify the checksum each time it rebuilds the container, throwing an error if they do not match.
+- If users want to update to a newer version, they can either delete the **devcontainer.lock** file, delete the particular entry, or reference a different version of it in their `devcontainer.json` file. If the version stored in both files doesn't match, the application should update the entry on the next build.
+- If during a first build the **devcontainer.lock** file does not exist, it should be created as part of the build process if and when it succeeds.
+
+The **devcontainer.lock** contains an array of:
+
+| Property | Type | Description |
+| :--- | :--- | :--- |
+| id | string | The fully qualified id of the feature as defined [here](./devcontainer-features.md#devcontainerjson-properties).|
+| options | string | The same options object passed to the feature in `devcontainer.json`.|
+| checksum | string | The checksum of the downloaded compressed release file.|
+
+The specification supports executing features multiple times with different options. This can be useful when a user wants to install multiple versions of sdk's, or simply execute whatever changes the feature makes to the operating system multiple times. -->

--- a/proposals/devcontainer-features-distribution.md
+++ b/proposals/devcontainer-features-distribution.md
@@ -43,7 +43,7 @@ Source code for the set follows the example file structure below:
 ├── ...
 ```
 
-Where `src` is a directory containing a sub-folder with the name of the feature (e.g. `src/dotnet` or `src/go`) with at least a file named `devcontainer-feature.json` that contains the feature metadata, and an `install.sh` script that implementing tools will use as the entrypoint to install the feature.  Each sub-directory should be named such that it matches the `id` field of the `devcontainer-feature.json`.  Other files can also be included in the feature's sub-directory, and will be packaged along side the two required files.  Any files that are not part of the feature's sub-directory (e.g. outside of `src/dotnet`) will not be packaged.
+Where `src` is a directory containing a sub-folder with the name of the feature (e.g. `src/dotnet` or `src/go`) with at least a file named `devcontainer-feature.json` that contains the feature metadata, and an `install.sh` script that implementing tools will use as the entrypoint to install the feature.  Each sub-directory should be named such that it matches the `id` field of the `devcontainer-feature.json`.  Other files can also be included in the feature's sub-directory, and will be included during the [packaging step](#packaging) along side the two required files.  Any files that are not part of the feature's sub-directory (e.g. outside of `src/dotnet`) will not included in the [packaging step](#packaging).
 
 Optionally, a mirrored `test` directory can be included with an accompanying `test.sh` script.  Implementing tools may use this to run tests against the given feature.
 
@@ -70,8 +70,6 @@ The `devcontainer-collection.json` is an auto-generated metadata file.
 | :--- | :--- | :--- |
 | sourceInformation | object | Metadata from the implementing packaging tool. |
 | features | array | The list of features that are contained in this collection.|
-<!-- | templates | array | The list of templates contained in this collection. Same information as the metadata file for the definition.| -->
-
 
 Each features's `devcontainer-feature.json` metadata file is appended into the `features` top-level array.
 
@@ -87,8 +85,9 @@ An OCI registry that implements the [OCI Artifact Distribution Specification](ht
 
 Each packaged feature is pushed to the registry following the naming convention `<registry>/<namespace>/<id>[:version]`, where version is the major, minor, and patch version of the feature, according to the semver specification.
 
-A custom media type `application/vnd.devcontainers` and `application/vnd.devcontainers.layer.v1+tar` are used as demonstrated below.
+> The `namespace` is a unique indentifier for the collection of features.  There are no strict rules for the `namespace`; however, one pattern is to set `namespace` equal to source repository's `<owner>/<repo>`. 
 
+A custom media type `application/vnd.devcontainers` and `application/vnd.devcontainers.layer.v1+tar` are used as demonstrated below.
 
 For example, the `go` feature in the `devcontainers/features` namespace at version `1.2.3` would be pushed to the ghcr.io OCI registry.  
 
@@ -128,3 +127,10 @@ oras push ${REGISTRY}/${NAMESPACE}:latest \
 
 A feature can be referenced directly in a user's [`devcontainer.json`](/docs/specs/devcontainer-reference.md#devcontainerjson) file by an HTTP URI that points to the tarball from the [package step](#packaging).
 
+### Addendum: Locally Referenced
+
+To aid in feature authorship, or in instances where a feature should not be published externally, individual features can be referenced locally from the project's file tree.
+
+A feature can be referenced directly in a user's [`devcontainer.json`](/docs/specs/devcontainer-reference.md#devcontainerjson) by relative path _inside_ the project directory.  A local feature may not be referenced outside of the project directory (`../` is not allowed), nor is an absolute path allowed.  
+
+The provided relative path is a path to the folder containing the feature's `devcontainer-feature.json` and `install.sh` file.

--- a/proposals/devcontainer-features-distribution.md
+++ b/proposals/devcontainer-features-distribution.md
@@ -4,10 +4,10 @@ This specification defines a pattern where community members and organizations c
 
 Goals include:
 
-- For community authors, a "self-served" mechanism for dev container feature publishing.
-- For community members, the ability to publish features, thus allowing  [supporting tools](../docs/specs/supporting-tools.md) to implement their own discovery mechanisms.
+- For community authors, a "self-served" mechanism for dev container feature publishing, either publicly or privately.
 - For users, the ability to validate the integrity of previously fetched assets. 
-- For users, the ability for a user to pin to a particular version (absolute, or semantic version) of a feature to allow consistent, repeatable environments.
+- For users, the ability for a user to pin to a particular version (absolute, or semantic version) of a feature to allow for consistent, repeatable environments.
+- The ability to standardize publishing such that [supporting tools](../docs/specs/supporting-tools.md) may implement mechanisms for feature discoverability.
 
 ## Source Code
 

--- a/proposals/devcontainer-features-distribution.md
+++ b/proposals/devcontainer-features-distribution.md
@@ -5,8 +5,7 @@ This specification defines a pattern where community members and organizations c
 Goals include:
 
 - For community authors, a "self-served" mechanism for dev container feature publishing.
-- For community members, the ability to publish will allow  [supporting tools](../docs/specs/supporting-tools.md) to implement their own discovery mechanisms.
-- For users, ease of discoverability of features via [supporting tools](../docs/specs/supporting-tools.md).
+- For community members, the ability to publish features, thus allowing  [supporting tools](../docs/specs/supporting-tools.md) to implement their own discovery mechanisms.
 - For users, the ability to validate the integrity of previously fetched assets. 
 - For users, the ability for a user to pin to a particular version (absolute, or semantic version) of a feature to allow consistent, repeatable environments.
 

--- a/proposals/devcontainer-features-distribution.md
+++ b/proposals/devcontainer-features-distribution.md
@@ -43,7 +43,7 @@ Source code for the set follows the example file structure below:
 ├── ...
 ```
 
-Where `src` is a directory containing a sub-folder with the name of the feature (e.g. `src/dotnet` or `src/go`) with at least a file named `devcontainer-feature.json` that contains the feature metadata, and an `install.sh` script that implementing tools will use as the entrypoint to install the feature.  Each sub-directory should be named such that it matches the `id` field of the `devcontainer-feature.json`.  Other files can also be included in the feature's sub-directory, and will be included during the [packaging step](#packaging) along side the two required files.  Any files that are not part of the feature's sub-directory (e.g. outside of `src/dotnet`) will not included in the [packaging step](#packaging).
+Where `src` is a directory containing a sub-folder with the name of the feature (e.g. `src/dotnet` or `src/go`) with at least a file named `devcontainer-feature.json` that contains the feature metadata, and an `install.sh` script that implementing tools will use as the entrypoint to install the feature.  Each sub-directory should be named such that it matches the `id` field of the `devcontainer-feature.json`.  Other files can also be included in the feature's sub-directory, and will be included during the [packaging step](#packaging) alongside the two required files.  Any files that are not part of the feature's sub-directory (e.g. outside of `src/dotnet`) will not included in the [packaging step](#packaging).
 
 Optionally, a mirrored `test` directory can be included with an accompanying `test.sh` script.  Implementing tools may use this to run tests against the given feature.
 

--- a/proposals/devcontainer-features-distribution.md
+++ b/proposals/devcontainer-features-distribution.md
@@ -7,7 +7,7 @@ Goals include:
 - For community authors, a "self-served" mechanism for dev container feature publishing.
 - For community members, the ability to publish will allow  [supporting tools](../docs/specs/supporting-tools.md) to implement their own discovery mechanisms.
 - For users, ease of discoverability of features via [supporting tools](../docs/specs/supporting-tools.md).
-- For users, the abilty to validate the origin of the asset and its integrity when compared to previous pulls. 
+- For users, the ability to validate the integrity of previously fetched assets. 
 - For users, the ability for a user to pin to a particular version (absolute, or semantic version) of a feature to allow consistent, repeatable environments.
 
 ## Source Code
@@ -35,7 +35,7 @@ Source code for the set follows the example file structure below:
 │   │   └── install.sh
 ├── test
 │   ├── dotnet
-│   │   ├── devcontainer-feature.json
+│   │   ├── test.sh
 │   │   └── ...
 │   └── go
 │   |   └── test.sh

--- a/proposals/devcontainer-features-distribution.md
+++ b/proposals/devcontainer-features-distribution.md
@@ -125,7 +125,7 @@ oras push ${REGISTRY}/${NAMESPACE}:latest \
 
 ### Directly Reference Tarball
 
-A feature can be referenced directly in a user's [`devcontainer.json`](/docs/specs/devcontainer-reference.md#devcontainerjson) file by an HTTP URI that points to the tarball from the [package step](#packaging).
+A feature can be referenced directly in a user's [`devcontainer.json`](/docs/specs/devcontainer-reference.md#devcontainerjson) file by an HTTP or HTTPS URI that points to the tarball from the [package step](#packaging).
 
 ### Addendum: Locally Referenced
 

--- a/proposals/devcontainer-features.md
+++ b/proposals/devcontainer-features.md
@@ -225,12 +225,8 @@ PIP="false"
 OPTIMIZE="true"
 ```
 
-These will be sourced and visible to the `install.sh` entrypoint script.  The following `install.sh` would print
-```
-3.10
-false
-true
-```
+These will be sourced and visible to the `install.sh` entrypoint script.  The following `install.sh`...
+
 
 ```bash
 #!/usr/bin/env bash
@@ -240,7 +236,12 @@ echo "Pip? $PIP"
 echo "Optimize? $OPTIMIZE"
 ```
 
-
+...output the following
+```
+3.10
+false
+true
+```
 
 ### Implementation Notes
 

--- a/proposals/devcontainer-features.md
+++ b/proposals/devcontainer-features.md
@@ -216,7 +216,6 @@ The user's `devcontainer.json` declared the python feature like so
     }
 }
 ```
-
 The emitted environment variables will be:
 
 ```env
@@ -236,7 +235,7 @@ echo "Pip? $PIP"
 echo "Optimize? $OPTIMIZE"
 ```
 
-...output the following
+...output the following:
 ```
 3.10
 false

--- a/proposals/devcontainer-features.md
+++ b/proposals/devcontainer-features.md
@@ -1,7 +1,10 @@
 # Dev container features reference
 
-Dev container 'features' are self-contained units of installation code and development container configuration. Features are designed to install atop a wide-range of base container images. 
-Features are generally designed to be installed on top of a subset of base container images (eg: debian-based images).
+Dev container 'features' are self-contained, shareable units of installation code and development container configuration.
+
+> While 'features' may be installed on top of any base image, the implementation of a feature might restrict it to a subset of possible base images.  
+> 
+> For example, some features may be authored to work with a certain linux distro (e.g. debian-based images that use the `apt` package manager).
 
 Feature metadata is captured by a `devcontainer-feature.json` file in the root folder of the feature.
 

--- a/proposals/devcontainer-features.md
+++ b/proposals/devcontainer-features.md
@@ -81,6 +81,9 @@ The properties are:
 | id | string | Reference to the particular feature to be included. |
 | options | object | Type of the option .|
 
+
+### Referencing a feature 
+
 The `id` is the main reference point for how to find and download a particular feature. `id` can be defined in any of the following ways:
 
 | Type | Description | Example |

--- a/proposals/devcontainer-features.md
+++ b/proposals/devcontainer-features.md
@@ -30,7 +30,6 @@ The properties of the file are as follows:
 | description | string | Description of the feature/definition. |
 | documentationURL | string | Url that points to the documentation of the feature. |
 | licenseURL | string | Url that points to the license of the feature. |
-| version | string | Version of the feature. |
 | keywords | array | List of keywords relevant to a user that would search for this definition/feature. |
 | options | object | Possible options to be passed as environment variables to the execution of the scripts |
 | containerEnv | object | A set of name value pairs that sets or overrides environment variables. |

--- a/proposals/devcontainer-features.md
+++ b/proposals/devcontainer-features.md
@@ -7,32 +7,14 @@ Feature metadata is captured by a `devcontainer-feature.json` file in the root f
 
 ## Folder Structure 
 
-A feature is a self contained entity in a folder. A feature release would be a tar file that contains all files part of the feature.
+A feature is a self contained entity in a folder with at least a `devcontainer-feature.json` and `install.sh` entrypoint script.  Additional files are permitted and are packaged along side the required files.
 
 ```
 +-- feature
 |    +-- devcontainer-feature.json
-|    +-- install.sh (default)
-|    +-- (other files)
-```
-
-In case `devcontainer-feature.json`  does not include a reference for the lifecycle scripts the application will look for the default script names and will execute them if available.
-
-In case there is intent to create a set of features that share code, it is possible to create a feature collection in the following way:
-
-```
-collectionFolder
-+-- devcontainer-collection.json
-+-- common (or similar)
-|    +-- (library files)
-+-- feature1
-|    +-- devcontainer-feature.json
 |    +-- install.sh
 |    +-- (other files)
-+-- feature2
-(etc)
 ```
-
 
 ## devcontainer-feature.json properties
 
@@ -70,8 +52,7 @@ Options
 | id.default | string | Default value for the option. |
 | id.description | string | Description for the option. |
 
-## devcontainer.json properties
-
+## devcontainer.json properties (feature related)
 
 Features are referenced in `devcontainer.json` under the top level `features` object. 
 
@@ -84,13 +65,13 @@ The properties are:
 
 ### Referencing a feature 
 
-The `id` is the main reference point for how to find and download a particular feature. `id` can be defined in any of the following ways:
+The `id` format specified dicates how a supporting tool will locate and download a given feature. `id` is one of the following:
 
 | Type | Description | Example |
 | :--- | :--- | :--- |
-| \<oci-registry\>/\<namespace\>/\<feature\>[:\<semantic-version\>] | Reference to feature in OCI registry(*) | ghcr.io/user/repo/go:1 |
-| https://<..URI..>/myFeatures.tgz#{feature} | Direct HTTPS URI to a tarball. | https:github.com/user/repo/releases/myFeatures.tgz#go|
-| ./{local-path}  -or-  | A relative to directory with a devcontainer-feature.json. | ./myGoFeature |
+| `<oci-registry>/<namespace>/<feature>[:<semantic-version>]` | Reference to feature in OCI registry(*) | ghcr.io/user/repo/go:1 |
+| `https://<uri-to-feature-tgz>` | Direct HTTPS URI to a tarball. | https://github.com/user/repo/releases/devcontainer-feature-go.tgz |
+| `./<path-to-feature-dir>`| A relative directory to folder containing a devcontainer-feature.json. | ./myGoFeature |
 
 `
 (*) OCI registry must implement the [OCI Artifact Distribution Specification](https://github.com/opencontainers/distribution-spec).  Some implementors can be [found here](https://oras.land/implementors/).
@@ -98,7 +79,7 @@ The `id` is the main reference point for how to find and download a particular f
 
 ## Versioning
 
-Each feature is individually [versioned according to the semver specification](https://semver.org/).  The `version` property in the respective `devcontainer-feature.json` file is updated to increment the feature's version.  
+Each feature is individually [versioned according to the semver specification](https://semver.org/).  The `version` property in the respective `devcontainer-feature.json` file is updated to increment the feature's version.
 
 Tooling that handles releasing features will not republish features if that exact version has already been published; however, tooling must republish major and minor versions in accordance with the semver specification.
 

--- a/proposals/devcontainer-features.md
+++ b/proposals/devcontainer-features.md
@@ -24,7 +24,7 @@ The properties of the file are as follows:
 
 | Property | Type | Description |
 | :--- | :--- | :--- |
-| id | string | Id of the feature/definition. The id should be unique in the context of the repository/published package where the feature exists. |
+| id | string | Id of the feature/definition. The id should be unique in the context of the repository/published package where the feature exists and must match the name of the directory where the `devcontainer-feature.json` resides. |
 | version | string | The semantic version of the feature. |
 | name | string | Name of the feature/definition. |
 | description | string | Description of the feature/definition. |
@@ -152,7 +152,7 @@ All feature `id` provided in `overrideFeatureInstallOrder` must also exist in th
 
 #### (2) installsAfter
 
-This propertry is defined in an individual feature's `devcontainer-feature.json` file by the feature author.  `installsAfter` allows an author to provide the tooling hints on loose dependencies between features.
+This property is defined in an individual feature's `devcontainer-feature.json` file by the feature author.  `installsAfter` allows an author to provide the tooling hints on loose dependencies between features.
 
 After `overrideFeatureInstallOrder` is resolved, any remaining features that declare an `installsAfter` must be installed after the features declared in the property, provided that the features have also been declared in the `features` property.
 
@@ -237,9 +237,9 @@ echo "Optimize? $OPTIMIZE"
 
 ...output the following:
 ```
-3.10
-false
-true
+Version is 3.10
+Pip? false
+Optimize? true
 ```
 
 ### Implementation Notes


### PR DESCRIPTION
relevant to: https://github.com/devcontainers/spec/issues/7

- Proposes OCI artifact registries as storage medium for features assets
- Clarifies packaging and distribution steps
- Clarifies several parts of the existing, general 'features' proposal 

For historical discussion, see https://github.com/devcontainers/spec/pull/40