### PR TITLE
typo with devcontainer-collection oci media type

### DIFF
--- a/proposals/devcontainer-features-distribution.md
+++ b/proposals/devcontainer-features-distribution.md
@@ -120,7 +120,7 @@ NAMESPACE=devcontainers/features
 
 oras push ${REGISTRY}/${NAMESPACE}:latest \
         --manifest-config /dev/null:application/vnd.devcontainers \
-                            ./devcontainer-collection.json.:application/vnd.devcontainers.layer.v1+json
+                            ./devcontainer-collection.json:application/vnd.devcontainers.collection.layer.v1+json
 ```
 
 ### Directly Reference Tarball


### PR DESCRIPTION
This is the media type the spiked GitHub action implements, and how https://github.com/devcontainers/features/pkgs/container/features is published today.

<img width="736" alt="image" src="https://user-images.githubusercontent.com/23246594/183669897-9a4d656f-f41b-4c6c-abf2-ecd413c3de12.png">
