### PR TITLE
Now supported in codespaces

### DIFF
--- a/docs/specs/supporting-tools.md
+++ b/docs/specs/supporting-tools.md
@@ -103,8 +103,6 @@ Some properties may apply differently to Codespaces.
 | Property or variable | Type | Description |
 |----------|---------|----------------------|
 | `mounts` | array | Codespaces ignores "bind" mounts with the exception of the Docker socket. Volume mounts are still allowed.|
-| `workspaceMount` | string | Not yet supported in Codespaces. |
-| `workspaceFolder` | string | Not yet supported in Codespaces. |
 | `forwardPorts` | array | Codespaces does not yet support the `"host:port"` variation of this property. |
 | `portsAttributes` | object | Codespaces does not yet support the `"host:port"` variation of this property.|
 | `shutdownAction` | enum | Does not apply to Codespaces. |


### PR DESCRIPTION
`waitFor` and `workspaceFolder` are now supported in Codespaces.