### PR TITLE
Backport updates related to https://github.com/devcontainers/devcontainers.github.io/pull/66 to the spec

### DIFF
--- a/docs/specs/devcontainer-features-distribution.md
+++ b/docs/specs/devcontainer-features-distribution.md
@@ -1,6 +1,6 @@
 # Distribution and Discovery of Dev Container Features
 
-**TL;DR Check out the [quick start repository](https://github.com/devcontainers/feature-template) to get going on distributing your own Dev Container Features.**
+**TL;DR Check out the [quick start repository](https://github.com/devcontainers/feature-template) to get started on distributing your own Dev Container Features.**
 
 This specification defines a pattern where community members and organizations can author and self-publish [Dev Container Features](./devcontainer-features.md). 
 

--- a/docs/specs/devcontainer-features-distribution.md
+++ b/docs/specs/devcontainer-features-distribution.md
@@ -1,5 +1,7 @@
 # Distribution and Discovery of Dev Container Features
 
+**TL;DR Check out the [quick start repository](https://github.com/devcontainers/feature-template) to get going on distributing your own Dev Container Features.**
+
 This specification defines a pattern where community members and organizations can author and self-publish [Dev Container Features](./devcontainer-features.md). 
 
 Goals include:
@@ -79,7 +81,7 @@ Each features's `devcontainer-feature.json` metadata file is appended into the `
 
 ## Distribution
 
-There are several supported ways to distribute features.  Distribution is handled by the implementing packaging tool.
+There are several supported ways to distribute Features. Distribution is handled by the implementing packaging tool such as the [Dev Container CLI](https://github.com/devcontainers/cli) or [Dev Container Publish GitHub Action](https://github.com/marketplace/actions/dev-container-publish). See the [quick start repository](https://github.com/devcontainers/feature-template) for a full working example.
 
 A user references a distributed feature in a `devcontainer.json` as defined in ['referencing a feature'](./devcontainer-features.md#Referencing-a-feature).
 

--- a/proposals/devcontainer-templates-distribution.md
+++ b/proposals/devcontainer-templates-distribution.md
@@ -1,6 +1,6 @@
 # Distribution and Discovery of Dev Container Templates
 
-**TL;DR Check out the [quick start repository](https://github.com/devcontainers/template-starter) to get going on distributing your own Dev Container Templates.**
+**TL;DR Check out the [quick start repository](https://github.com/devcontainers/template-starter) to get started on distributing your own Dev Container Templates.**
 
 This specification defines a pattern where community members and organizations can author and self-publish [Dev Container Templates](./devcontainer-templates.md). 
 

--- a/proposals/devcontainer-templates-distribution.md
+++ b/proposals/devcontainer-templates-distribution.md
@@ -1,5 +1,7 @@
 # Distribution and Discovery of Dev Container Templates
 
+**TL;DR Check out the [quick start repository](https://github.com/devcontainers/template-starter) to get going on distributing your own Dev Container Templates.**
+
 This specification defines a pattern where community members and organizations can author and self-publish [Dev Container Templates](./devcontainer-templates.md). 
 
 Goals include:
@@ -77,7 +79,7 @@ Each Template's `devcontainer-template.json` metadata file is appended into the 
 
 ## Distribution
 
-There are several supported ways to distribute Templates.  Distribution is handled by the implementing packaging tool.
+There are several supported ways to distribute Templates. Distribution is handled by the implementing packaging tool such as the **[Dev Container CLI](https://github.com/devcontainers/cli)** or **[Dev Container Publish GitHub Action](https://github.com/marketplace/actions/dev-container-publish)**.
 
 A user can add a Template in to their projects as defined by the [supporting Tools](../docs/specs/supporting-tools.md#supporting-tools-and-services).
 

--- a/proposals/devcontainer-templates.md
+++ b/proposals/devcontainer-templates.md
@@ -94,10 +94,12 @@ A Template's `options` property is used by a supporting tool to prompt for diffe
 
 Consider a `java` Template with the following folder structure:
 
+```
 +-- java
 |   +-- devcontainer-template.json
 |   +-- .devcontainer
 |       +-- devcontainer.json
+```
 
 Suppose the `java` Template has the following `options` parameters declared in the `devcontainer-template.json` file:
 


### PR DESCRIPTION
Backports https://github.com/devcontainers/devcontainers.github.io/pull/66 to the spec repo.

@bamurtaugh LMK if it would be easier to merge this into https://github.com/devcontainers/spec/pull/128 instead. 