### PR TITLE
Create `devContainerFeature.schema.json`

### DIFF
--- a/schemas/devContainerFeature.schema.json
+++ b/schemas/devContainerFeature.schema.json
@@ -1,0 +1,185 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Defines a dev container Feature",
+  "allowComments": true,
+  "allowTrailingCommas": false,
+  "definitions": {
+    "Feature": {
+      "additionalProperties": false,
+      "properties": {
+        "capAdd": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "consecutiveId": {
+          "type": "string"
+        },
+        "containerEnv": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "customizations": {},
+        "description": {
+          "type": "string"
+        },
+        "documentationURL": {
+          "type": "string"
+        },
+        "entrypoint": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "init": {
+          "type": "boolean"
+        },
+        "installsAfter": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "licenseURL": {
+          "type": "string"
+        },
+        "mounts": {
+          "items": {
+            "$ref": "#/definitions/Mount"
+          },
+          "type": "array"
+        },
+        "name": {
+          "type": "string"
+        },
+        "options": {
+          "additionalProperties": {
+            "$ref": "#/definitions/FeatureOption"
+          },
+          "type": "object"
+        },
+        "privileged": {
+          "type": "boolean"
+        },
+        "securityOpt": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "version"
+      ],
+      "type": "object"
+    },
+    "FeatureOption": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "default": {
+              "type": "boolean"
+            },
+            "description": {
+              "type": "string"
+            },
+            "type": {
+              "const": "boolean",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "default": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "enum": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": {
+              "const": "string",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "default": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "proposals": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": {
+              "const": "string",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "Mount": {
+      "additionalProperties": false,
+      "properties": {
+        "external": {
+          "type": "boolean"
+        },
+        "source": {
+          "type": "string"
+        },
+        "target": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "bind",
+            "volume"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "source",
+        "target"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/schemas/devContainerFeature.schema.json
+++ b/schemas/devContainerFeature.schema.json
@@ -47,7 +47,7 @@
           "type": "boolean"
         },
         "installsAfter": {
-          "description": "Array of ID’s of Features that should execute before this one. Allows control for feature authors on soft dependencies between different Features.",
+          "description": "Array of ID's of Features that should execute before this one. Allows control for feature authors on soft dependencies between different Features.",
           "items": {
             "type": "string"
           },
@@ -58,6 +58,7 @@
           "type": "string"
         },
         "mounts": {
+          "description": "Mounts a volume or bind mount into the container.",
           "items": {
             "$ref": "#/definitions/Mount"
           },
@@ -108,9 +109,11 @@
               "type": "boolean"
             },
             "description": {
+              "description": "A description of the option displayed to the user by a supporting tool.",
               "type": "string"
             },
             "type": {
+              "description": "The type of the option. Can be 'boolean' or 'string'.  Options of type 'string' should use the 'enum' or 'proposals' property to provide a list of allowed values.",
               "const": "boolean",
               "type": "string"
             }
@@ -129,6 +132,7 @@
               "type": "string"
             },
             "description": {
+              "description": "A description of the option displayed to the user by a supporting tool.",
               "type": "string"
             },
             "enum": {
@@ -139,6 +143,7 @@
               "type": "array"
             },
             "type": {
+              "description": "The type of the option. Can be 'boolean' or 'string'.  Options of type 'string' should use the 'enum' or 'proposals' property to provide a list of allowed values.",
               "const": "string",
               "type": "string"
             }
@@ -158,6 +163,7 @@
               "type": "string"
             },
             "description": {
+              "description": "A description of the option displayed to the user by a supporting tool.",
               "type": "string"
             },
             "proposals": {
@@ -168,6 +174,7 @@
               "type": "array"
             },
             "type": {
+              "description": "The type of the option. Can be 'boolean' or 'string'.  Options of type 'string' should use the 'enum' or 'proposals' property to provide a list of allowed values.",
               "const": "string",
               "type": "string"
             }
@@ -185,16 +192,16 @@
       "description": "Mounts a volume or bind mount into the container.",
       "additionalProperties": false,
       "properties": {
-        "external": {
-          "type": "boolean"
-        },
         "source": {
+          "description": "Mount source.",
           "type": "string"
         },
         "target": {
+          "description": "Mount target.",
           "type": "string"
         },
         "type": {
+          "description": "Type of mount. Can be 'bind' or 'volume'.",
           "enum": [
             "bind",
             "volume"

--- a/schemas/devContainerFeature.schema.json
+++ b/schemas/devContainerFeature.schema.json
@@ -1,8 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "description": "Defines a dev container Feature",
-  "allowComments": true,
-  "allowTrailingCommas": false,
   "definitions": {
     "Feature": {
       "additionalProperties": false,
@@ -23,7 +20,7 @@
           "type": "object"
         },
         "customizations": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "type": "object"
         },
         "description": {
@@ -85,8 +82,10 @@
       "type": "object"
     },
     "FeatureOption": {
+      "additionalItems": false,
       "anyOf": [
         {
+          "description": "Option value is represented with a boolean value.",
           "additionalProperties": false,
           "properties": {
             "default": {
@@ -101,12 +100,14 @@
             }
           },
           "required": [
-            "type"
+            "type",
+            "default"
           ],
           "type": "object"
         },
         {
           "additionalProperties": false,
+          "description": "Option value is strictly as a member of the 'enum' array.  User cannot provide their own value.",
           "properties": {
             "default": {
               "type": "string"
@@ -126,12 +127,14 @@
             }
           },
           "required": [
-            "type"
+            "type",
+            "enum"
           ],
           "type": "object"
         },
         {
           "additionalProperties": false,
+          "description": "Option value is either a member of the 'proposals' array, or a custom, user-provided value.",
           "properties": {
             "default": {
               "type": "string"
@@ -151,7 +154,8 @@
             }
           },
           "required": [
-            "type"
+            "type",
+            "proposals"
           ],
           "type": "object"
         }
@@ -184,5 +188,12 @@
       ],
       "type": "object"
     }
-  }
+  },
+  "oneOf": [
+    {
+      "type": "object",
+      "$ref": "#/definitions/Feature",
+      "additionalProperties": false
+    }
+  ]
 }

--- a/schemas/devContainerFeature.schema.json
+++ b/schemas/devContainerFeature.schema.json
@@ -1,50 +1,60 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "definitions": {
+  "title": "Development Container Feature Metadata",
+  "description": "Development Container Features Metadata (devcontainer-feature.json). See https://containers.dev/implementors/features/ for more information.",
+    "definitions": {
     "Feature": {
       "additionalProperties": false,
       "properties": {
         "capAdd": {
+					"description": "Passes docker capabilities to include when creating the dev container.",
+					"examples": [ "SYS_PTRACE" ],
           "items": {
             "type": "string"
           },
           "type": "array"
         },
-        "consecutiveId": {
-          "type": "string"
-        },
         "containerEnv": {
+          "description": "Container environment variables.",
           "additionalProperties": {
             "type": "string"
           },
           "type": "object"
         },
         "customizations": {
+          "description": "Tool-specific configuration. Each tool should use a JSON object subproperty with a unique name to group its customizations.",
           "additionalProperties": true,
           "type": "object"
         },
         "description": {
+          "description": "Description of the Feature. For the best appearance in an implementing tool, refrain from including markdown or HTML in the description.",
           "type": "string"
         },
         "documentationURL": {
+          "description": "URL to documentation for the Feature.",
           "type": "string"
         },
         "entrypoint": {
+          "description": "Entrypoint script that should fire at container start up.",
           "type": "string"
         },
         "id": {
+          "description": "ID of the Feature. The id should be unique in the context of the repository/published package where the feature exists and must match the name of the directory where the devcontainer-feature.json resides.",
           "type": "string"
         },
         "init": {
+          "description": "Adds the tiny init process to the container (--init) when the Feature is used.",
           "type": "boolean"
         },
         "installsAfter": {
+          "description": "Array of ID’s of Features that should execute before this one. Allows control for feature authors on soft dependencies between different Features.",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "licenseURL": {
+          "description": "URL to the license for the Feature.",
           "type": "string"
         },
         "mounts": {
@@ -54,24 +64,29 @@
           "type": "array"
         },
         "name": {
+          "description": "Display name of the Feature.",
           "type": "string"
         },
         "options": {
+          "description": "Possible user-configurable options for this Feature. The selected options will be passed as environment variables when installing the Feature into the container.",
           "additionalProperties": {
             "$ref": "#/definitions/FeatureOption"
           },
           "type": "object"
         },
         "privileged": {
+          "description": "Sets privileged mode (--privileged) for the container.",
           "type": "boolean"
         },
         "securityOpt": {
+          "description": "Sets container security options to include when creating the container.",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "version": {
+          "description": "The version of the Feature. Follows the semanatic versioning (semver) specification.",
           "type": "string"
         }
       },
@@ -89,6 +104,7 @@
           "additionalProperties": false,
           "properties": {
             "default": {
+              "description": "Default value if the user omits this option from their configuration.",
               "type": "boolean"
             },
             "description": {
@@ -107,15 +123,16 @@
         },
         {
           "additionalProperties": false,
-          "description": "Option value is strictly as a member of the 'enum' array.  User cannot provide their own value.",
           "properties": {
             "default": {
+              "description": "Default value if the user omits this option from their configuration.",
               "type": "string"
             },
             "description": {
               "type": "string"
             },
             "enum": {
+              "description": "Allowed values for this option.  Unlike 'proposals', the user cannot provide a custom value not included in the 'enum' array.",
               "items": {
                 "type": "string"
               },
@@ -128,21 +145,23 @@
           },
           "required": [
             "type",
-            "enum"
+            "enum",
+            "default"
           ],
           "type": "object"
         },
         {
           "additionalProperties": false,
-          "description": "Option value is either a member of the 'proposals' array, or a custom, user-provided value.",
           "properties": {
             "default": {
+              "description": "Default value if the user omits this option from their configuration.",
               "type": "string"
             },
             "description": {
               "type": "string"
             },
             "proposals": {
+              "description": "Suggested values for this option.  Unlike 'enum', the 'proposals' attribute indicates the installation script can handle arbitrary values provided by the user.",
               "items": {
                 "type": "string"
               },
@@ -155,13 +174,15 @@
           },
           "required": [
             "type",
-            "proposals"
+            "proposals",
+            "default"
           ],
           "type": "object"
         }
       ]
     },
     "Mount": {
+      "description": "Mounts a volume or bind mount into the container.",
       "additionalProperties": false,
       "properties": {
         "external": {

--- a/schemas/devContainerFeature.schema.json
+++ b/schemas/devContainerFeature.schema.json
@@ -22,7 +22,10 @@
           },
           "type": "object"
         },
-        "customizations": {},
+        "customizations": {
+          "additionalProperties": false,
+          "type": "object"
+        },
         "description": {
           "type": "string"
         },


### PR DESCRIPTION
ref: https://github.com/devcontainers/spec/issues/140

A schema generated from https://github.com/devcontainers/cli/blob/main/src/spec-configuration/containerFeaturesConfiguration.ts#L25-L72

An example of this JSON file "in the wild" can be found in the [devcontainers/features](https://github.com/devcontainers/features/blob/main/src/docker-in-docker/devcontainer-feature.json) repo.

Examples of this validation file being piped into a VS Code extension:

<img width="700" alt="image" src="https://user-images.githubusercontent.com/23246594/207140746-68bfdd2b-b0b1-457d-affe-de4cd768dfc5.png">
<img width="496" alt="image" src="https://user-images.githubusercontent.com/23246594/207140881-d8e8a356-a195-496f-b5c9-e28180710f8c.png">
<img width="1018" alt="image" src="https://user-images.githubusercontent.com/23246594/207140932-e648a0f9-946f-48bb-8e60-efc89a8318fc.png">
<img width="740" alt="image" src="https://user-images.githubusercontent.com/23246594/207141007-e5c3db83-bc53-453a-be00-3857fcb716c1.png">
