### PR TITLE
Proposal: First class secrets support in dev containers implementations

### DIFF
--- a/proposals/secrets-support.md
+++ b/proposals/secrets-support.md
@@ -23,7 +23,7 @@ A [supporting tool](https://containers.dev/supporting#tools) (ie, the [dev conta
   3. Securely handle secrets
 
 ### Passing secrets to commands
-Secrets are not part of devcontainers specification and we do not expect users to store secrets inside devcontainer.json file.
+Secrets are not part of dev containers specification and we do not expect users to store secrets inside devcontainer.json file.
 
 Secrets should be passed to the following devcontainers CLI commands.
 

--- a/proposals/secrets-support.md
+++ b/proposals/secrets-support.md
@@ -5,7 +5,7 @@ Secrets are variables that hold sensitive values and needs to be handled securel
 
 ## Goal
 
-Support Secrets as a first class feature in devcontainers CLI.
+Support secrets as a first class feature in devcontainers CLI.
 
 This feature should comprise of the ability to securely pass in the secrets in CLI commands, make them available for users to consume similar to remoteEnv and containerEnv, and be processed and handled securely at all times.
 This functionality will allow consumers to be able to use secrets more predictably and securely with devcontainers CLI.

--- a/proposals/secrets-support.md
+++ b/proposals/secrets-support.md
@@ -1,0 +1,76 @@
+# First class secrets support in devcontainers CLI
+
+## What are secrets
+Secrets are variables that hold sensitive values and needs to be handled securely at all times (API keys, passwords etc.). Users can change a secret's value at anytime, and the devcontainers CLI should support dynamically changing secrets without having to rebuild the container.
+
+## Goal
+
+Support Secrets as a first class feature in devcontainers CLI.
+
+This feature should comprise of the ability to securely pass in the secrets in CLI commands, make them available for users to consume similar to remoteEnv and containerEnv, and be processed and handled securely at all times.
+This functionality will allow consumers to be able to use secrets more predictably and securely with devcontainers CLI.
+
+## Motivation
+
+Today Codespaces pass secret variables as `remoteEnv` since there are no other mechanisms to pass them explicitly as secrets. The devcontainers CLI do not (and need not) treat `remoteEnv` as secrets. Having explicit support for secrets will help eliminating security threats such as leaking secrets, as well as in improving customer confidence.
+
+## Proposal
+
+Following are the three main functional changes to the CLI to support this feature.
+
+  1. Ability to pass secrets to commands
+  2. Apply/use secrets similar to `remoteEnv`
+  3. Securely handle secrets
+
+### Passing secrets to commands
+Secrets are not part of devcontainers specification and we do not expect users to store secrets inside devcontainer.json file.
+
+Secrets should be passed to the following devcontainers CLI commands.
+
+#### **Phase 1**
+ - up
+ - run-user-commands
+
+`up`, `run-user-commands` will use the secrets for usecases like lifecycle hooks (similar to remoteEnv). We do not plan secrets support for `build` command since we do not have a demostrated requirement, as well as to avoid potentially baking in the user secrets into the docker images.
+
+#### **Phase 2**
+In phase 2 the support for secrets can be expanded to additional commands such as `set-up` and `exec`.
+
+#### **Input format**
+Best way to pass secrets would be through a json/env file, where in the file path is supplied in a command line argument `--secrets-file`.
+
+Today the devcontaners CLI commands accept remote environment variables of the format name=value. However that format may not work as it is here, since in many cases the secret values may span multiple lines. One value to workaround that problem is by base64 encoding the values.
+
+Example secrets file:
+```
+API_KEY=YWRzamhzZDZkZndkamZ3ZGU3ZWR3ZndlZGZkamVkd2Y3d2VkZndl
+NUGET_CONFIG=PGNvbmZpZz4KICAgIDxhZGQga2V5PSJkZXBlbmRlbmN5VmVyc2lvbiIgdmFsdWU9IkhpZ2hlc3QiIC8+CiAgICA8YWRkIGtleT0iaHR0cF9wcm94eSIgdmFsdWU9Imh0dHA6Ly9jb21wYW55LXNxdWlkOjMxMjhAY29udG9zby5jb20iIC8+CjwvY29uZmlnPg==
+PASSWORD=U2ltcGxlIFBhc3N3b3Jkcw==
+```
+
+Example secrets file in json format:
+```json
+[
+  	{
+		"name": "API_KEY",
+		"value": "adsjhsd6dfwdjfwde7edwfwedfdjedwf7wedfwe"
+	},
+	{
+		"name": "NUGET_CONFIG",
+		"value": "<config>\n    <add key=\"dependencyVersion\" value=\"Highest\" />\n    <add key=\"http_proxy\" value=\"http://company-squid:3128@contoso.com\" />\n</config>"
+	},
+	{
+		"name": "PASSWORD",
+		"value": "Simple Passwords"
+	}
+]
+```
+
+### Using secrets in the CLI
+Today Codespaces as a consumer is leveraging `remoteEnv` to pass secrets into the CLI. So it is a basic requirement that secrets should be used and behave the same way as `remoteEnv` do.
+
+### Securely handle secrets
+Secrets should be handled securely at all times.
+- Secrets should not be passed as plain text in command line
+- Do not be persist secrets on the container labels or long lived permanent caches
+- Redact secrets to prevent them being written in plain text into logs and console output.

--- a/proposals/secrets-support.md
+++ b/proposals/secrets-support.md
@@ -23,7 +23,7 @@ A [supporting tool](https://containers.dev/supporting#tools) (ie, for example th
   3. Securely handle secrets
 
 ### Passing secrets in
-Secrets are not part of dev containers specification and we do not expect users to store secrets inside devcontainer.json file. A conforming implemntation should provide a secure mechasism to pass secrets, such as a secrets file, Windows credential manager, Mac keychain, Azure keyvault etc. for example.
+Secrets are not part of dev containers specification and we do not expect users to store secrets inside `devcontainer.json` file. A conforming implementation should provide a secure mechanism to pass secrets, such as a secrets file, Windows credential manager, Mac keychain, Azure keyvault etc. for example.
 
 #### **Example**
 

--- a/proposals/secrets-support.md
+++ b/proposals/secrets-support.md
@@ -39,7 +39,7 @@ In phase 2 the support for secrets can be expanded to additional commands such a
 #### **Input format**
 Best way to pass secrets would be through a json/env file, where in the file path is supplied in a command line argument `--secrets-file`.
 
-Today the devcontaners CLI commands accept remote environment variables of the format name=value. However that format may not work as it is here, since in many cases the secret values may span multiple lines. One value to workaround that problem is by base64 encoding the values.
+Today the devcontaners CLI [commands accept](https://github.com/devcontainers/cli/blob/5c81479f0342947dd3e52a5984b9150e5feb8fd6/src/spec-node/devContainersSpecCLI.ts#L114) remote environment variables of the format name=value. However that format may not work as it is here, since in many cases the secret values may span multiple lines. One way to workaround that problem is by base64 encoding the values.
 
 Example secrets file:
 ```
@@ -66,7 +66,7 @@ Example secrets file in json format:
 ]
 ```
 
-Further simplified json kv pair format:
+Further simplified json kv pair format (Preffered):
 ```json
 {
 	"API_KEY": "adsjhsd6dfwdjfwde7edwfwedfdjedwf7wedfwe",

--- a/proposals/secrets-support.md
+++ b/proposals/secrets-support.md
@@ -23,40 +23,12 @@ A [supporting tool](https://containers.dev/supporting#tools) (ie, for example th
   3. Securely handle secrets
 
 ### Passing secrets in
-Secrets are not part of dev containers specification and we do not expect users to store secrets inside devcontainer.json file. It is recommended to pass the secrets in separate a file.
+Secrets are not part of dev containers specification and we do not expect users to store secrets inside devcontainer.json file. A conforming implemntation should provide a secure mechasism to pass secrets, such as a secrets file, Windows credential manager, Mac keychain, Azure keyvault etc. for example.
 
-In the future the support could be expanded to accept secrets from additional sources such as Windows credential manager, Mac keychain, Azure keyvault etc.
+#### **Example**
 
-#### **Input format**
+Using a file to pass in the secrets can be one of the simple approaches to adopt. In this example the supporting tool can input secrets in a JSON file format.
 
-Using `env` files can be a basic and simple option. However that format may not work as it is in some cases, for example the secret values may often span multiple lines. One way to workaround that problem is by base64 encoding the values.
-
-1. Example secrets env file:
-	```
-	API_KEY=YWRzamhzZDZkZndkamZ3ZGU3ZWR3ZndlZGZkamVkd2Y3d2VkZndl
-	NUGET_CONFIG=PGNvbmZpZz4KICAgIDxhZGQga2V5PSJkZXBlbmRlbmN5VmVyc2lvbiIgdmFsdWU9IkhpZ2hlc3QiIC8+CiAgICA8YWRkIGtleT0iaHR0cF9wcm94eSIgdmFsdWU9Imh0dHA6Ly9jb21wYW55LXNxdWlkOjMxMjhAY29udG9zby5jb20iIC8+CjwvY29uZmlnPg==
-	PASSWORD=U2ltcGxlIFBhc3N3b3Jkcw==
-	```
-
-2. Example secrets file in json format:
-	```json
-	[
-		{
-			"name": "API_KEY",
-			"value": "adsjhsd6dfwdjfwde7edwfwedfdjedwf7wedfwe"
-		},
-		{
-			"name": "NUGET_CONFIG",
-			"value": "<config>\n    <add key=\"dependencyVersion\" value=\"Highest\" />\n    <add key=\"http_proxy\" value=\"http://company-squid:3128@contoso.com\" />\n</config>"
-		},
-		{
-			"name": "PASSWORD",
-			"value": "Simple Passwords"
-		}
-	]
-	```
-
-3. Further simplified json kv pair format:
 	```json
 	{
 		"API_KEY": "adsjhsd6dfwdjfwde7edwfwedfdjedwf7wedfwe",
@@ -78,7 +50,8 @@ Secrets should be handled securely at all times.
 Notes on how this proposal may be adopted by the dev containers CLI (reference implementation).
 
 ### Passing secrets to the commands
-Secrets should not be passed directly in the command line since that would risk it getting stored in command history. Best way to pass secrets would be through a json/env file, where in the file path is supplied in a command line argument named `--secrets-file`.
+Secrets should not be passed directly in the command line since that would risk it getting stored in command history. Best way to pass secrets would be through a json file, where in the file path is supplied in a command line argument named `--secrets-file`.
+The dev containers CLI may support a default json file path with respect to the .devcontainer root, which will be used if the user does not provide a path explicitly using `--secrets-file` argument.
 
 Secrets should be passed to the following dev containers CLI commands.
 

--- a/proposals/secrets-support.md
+++ b/proposals/secrets-support.md
@@ -31,7 +31,7 @@ Secrets should be passed to the following devcontainers CLI commands.
  - up
  - run-user-commands
 
-`up`, `run-user-commands` will use the secrets for usecases like lifecycle hooks (similar to remoteEnv). We do not plan secrets support for `build` command since we do not have a demostrated requirement, as well as to avoid potentially baking in the user secrets into the docker images.
+`up`, `run-user-commands` will use the secrets for usecases like lifecycle hooks (similar to remoteEnv). We do not plan secrets support for `build` command since we do not have a demonstrated requirement, as well as to avoid potentially baking in the user secrets into the docker images.
 
 #### **Phase 2**
 In phase 2 the support for secrets can be expanded to additional commands such as `set-up` and `exec`.

--- a/proposals/secrets-support.md
+++ b/proposals/secrets-support.md
@@ -66,7 +66,7 @@ Example secrets file in json format:
 ]
 ```
 
-Further simplified json kv pair format (Preffered):
+Further simplified json kv pair format (Prefered):
 ```json
 {
 	"API_KEY": "adsjhsd6dfwdjfwde7edwfwedfdjedwf7wedfwe",

--- a/proposals/secrets-support.md
+++ b/proposals/secrets-support.md
@@ -1,85 +1,92 @@
-# First class secrets support in devcontainers CLI
+# First class secrets support in dev containers implementations
 
 ## What are secrets
-Secrets are variables that hold sensitive values and needs to be handled securely at all times (API keys, passwords etc.). Users can change a secret's value at anytime, and the devcontainers CLI should support dynamically changing secrets without having to rebuild the container.
+Secrets are variables that hold sensitive values and need to be handled securely at all times (API keys, passwords etc.). Users can change a secret's value at any time, and a conforming dev containers implementation should support dynamically changing secrets without having to rebuild the container.
 
 ## Goal
 
-Support secrets as a first class feature in devcontainers CLI.
+Support secrets as a first class feature in dev containers implementations.
 
-This feature should comprise of the ability to securely pass in the secrets in CLI commands, make them available for users to consume similar to remoteEnv and containerEnv, and be processed and handled securely at all times.
-This functionality will allow consumers to be able to use secrets more predictably and securely with devcontainers CLI.
+This feature should consist of the ability to securely pass in the secrets, make them available for users to consume similar to remoteEnv and containerEnv, and be processed and handled securely at all times.
+This functionality will allow consumers to be able to use secrets more predictably and securely with their dev containers implementation.
 
 ## Motivation
 
-Today Codespaces pass secret variables as `remoteEnv` since there are no other mechanisms to pass them explicitly as secrets. The devcontainers CLI do not (and need not) treat `remoteEnv` as secrets. Having explicit support for secrets will help eliminating security threats such as leaking secrets, as well as in improving customer confidence.
+Today many consumers pass secret variables as `remoteEnv`, since there are no other mechanisms to pass them explicitly as secrets. The dev containers reference implementation do not (and need not) treat `remoteEnv` as secrets. Having explicit support for secrets will help eliminate security threats such as leaking secrets, as well as in improving customer confidence.
 
 ## Proposal
 
-A [supporting tool](https://containers.dev/supporting#tools) (ie, the [dev container CLI reference implementation](https://github.com/devcontainers/cli) should behave according to the following properties:
+A [supporting tool](https://containers.dev/supporting#tools) (ie, for example the [dev container CLI reference implementation](https://github.com/devcontainers/cli)) should behave according to the following properties:
 
   1. Ability to pass secrets to commands
   2. Apply/use secrets similar to `remoteEnv`
   3. Securely handle secrets
 
-### Passing secrets to commands
-Secrets are not part of dev containers specification and we do not expect users to store secrets inside devcontainer.json file.
+### Passing secrets in
+Secrets are not part of dev containers specification and we do not expect users to store secrets inside devcontainer.json file. It is recommended to pass the secrets in separate a file.
 
-Secrets should be passed to the following devcontainers CLI commands.
+In the future the support could be expanded to accept secrets from additional sources such as Windows credential manager, Mac keychain, Azure keyvault etc.
+
+#### **Input format**
+
+Using `env` files can be a basic and simple option. However that format may not work as it is in some cases, for example the secret values may often span multiple lines. One way to workaround that problem is by base64 encoding the values.
+
+1. Example secrets env file:
+	```
+	API_KEY=YWRzamhzZDZkZndkamZ3ZGU3ZWR3ZndlZGZkamVkd2Y3d2VkZndl
+	NUGET_CONFIG=PGNvbmZpZz4KICAgIDxhZGQga2V5PSJkZXBlbmRlbmN5VmVyc2lvbiIgdmFsdWU9IkhpZ2hlc3QiIC8+CiAgICA8YWRkIGtleT0iaHR0cF9wcm94eSIgdmFsdWU9Imh0dHA6Ly9jb21wYW55LXNxdWlkOjMxMjhAY29udG9zby5jb20iIC8+CjwvY29uZmlnPg==
+	PASSWORD=U2ltcGxlIFBhc3N3b3Jkcw==
+	```
+
+2. Example secrets file in json format:
+	```json
+	[
+		{
+			"name": "API_KEY",
+			"value": "adsjhsd6dfwdjfwde7edwfwedfdjedwf7wedfwe"
+		},
+		{
+			"name": "NUGET_CONFIG",
+			"value": "<config>\n    <add key=\"dependencyVersion\" value=\"Highest\" />\n    <add key=\"http_proxy\" value=\"http://company-squid:3128@contoso.com\" />\n</config>"
+		},
+		{
+			"name": "PASSWORD",
+			"value": "Simple Passwords"
+		}
+	]
+	```
+
+3. Further simplified json kv pair format:
+	```json
+	{
+		"API_KEY": "adsjhsd6dfwdjfwde7edwfwedfdjedwf7wedfwe",
+		"NUGET_CONFIG": "<config>\n    <add key=\"dependencyVersion\" value=\"Highest\" />\n    <add key=\"http_proxy\" value=\"http://company-squid:3128@contoso.com\" />\n</config>",
+		"PASSWORD": "Simple Passwords"
+	}
+	```
+
+### Using secrets
+Today many consumers are leveraging `remoteEnv` to pass in secrets. So it is a basic requirement that secrets should be used and behave the same way as `remoteEnv` do.
+
+### Securely handle secrets
+Secrets should be handled securely at all times.
+- Secrets should not be exposed in plan text at rest and in transit.
+- Do not persist secrets on the container labels or long lived permanent caches
+- Redact/mask secrets before writing to logs and output.
+
+## Notes
+Notes on how this proposal may be adopted by the dev containers CLI (reference implementation).
+
+### Passing secrets to the commands
+Secrets should not be passed directly in the command line since that would risk it getting stored in command history. Best way to pass secrets would be through a json/env file, where in the file path is supplied in a command line argument named `--secrets-file`.
+
+Secrets should be passed to the following dev containers CLI commands.
 
 #### **Phase 1**
  - up
  - run-user-commands
 
-`up`, `run-user-commands` will use the secrets for usecases like lifecycle hooks (similar to remoteEnv). We do not plan secrets support for `build` command since we do not have a demonstrated requirement, as well as to avoid potentially baking in the user secrets into the docker images.
+`up`, `run-user-commands` will use the secrets for use cases like lifecycle hooks (similar to remoteEnv). We do not plan secrets support for `build` command since we do not have a demonstrated requirement, as well as to avoid potentially baking in the user secrets into the docker images.
 
 #### **Phase 2**
 In phase 2 the support for secrets can be expanded to additional commands such as `set-up` and `exec`.
-
-#### **Input format**
-Best way to pass secrets would be through a json/env file, where in the file path is supplied in a command line argument `--secrets-file`.
-
-Today the devcontaners CLI [commands accept](https://github.com/devcontainers/cli/blob/5c81479f0342947dd3e52a5984b9150e5feb8fd6/src/spec-node/devContainersSpecCLI.ts#L114) remote environment variables of the format name=value. However that format may not work as it is here, since in many cases the secret values may span multiple lines. One way to workaround that problem is by base64 encoding the values.
-
-Example secrets file:
-```
-API_KEY=YWRzamhzZDZkZndkamZ3ZGU3ZWR3ZndlZGZkamVkd2Y3d2VkZndl
-NUGET_CONFIG=PGNvbmZpZz4KICAgIDxhZGQga2V5PSJkZXBlbmRlbmN5VmVyc2lvbiIgdmFsdWU9IkhpZ2hlc3QiIC8+CiAgICA8YWRkIGtleT0iaHR0cF9wcm94eSIgdmFsdWU9Imh0dHA6Ly9jb21wYW55LXNxdWlkOjMxMjhAY29udG9zby5jb20iIC8+CjwvY29uZmlnPg==
-PASSWORD=U2ltcGxlIFBhc3N3b3Jkcw==
-```
-
-Example secrets file in json format:
-```json
-[
-  	{
-		"name": "API_KEY",
-		"value": "adsjhsd6dfwdjfwde7edwfwedfdjedwf7wedfwe"
-	},
-	{
-		"name": "NUGET_CONFIG",
-		"value": "<config>\n    <add key=\"dependencyVersion\" value=\"Highest\" />\n    <add key=\"http_proxy\" value=\"http://company-squid:3128@contoso.com\" />\n</config>"
-	},
-	{
-		"name": "PASSWORD",
-		"value": "Simple Passwords"
-	}
-]
-```
-
-Further simplified json kv pair format (Prefered):
-```json
-{
-	"API_KEY": "adsjhsd6dfwdjfwde7edwfwedfdjedwf7wedfwe",
-	"NUGET_CONFIG": "<config>\n    <add key=\"dependencyVersion\" value=\"Highest\" />\n    <add key=\"http_proxy\" value=\"http://company-squid:3128@contoso.com\" />\n</config>",
-	"PASSWORD": "Simple Passwords"
-}
-```
-
-### Using secrets in the CLI
-Today Codespaces as a consumer is leveraging `remoteEnv` to pass secrets into the CLI. So it is a basic requirement that secrets should be used and behave the same way as `remoteEnv` do.
-
-### Securely handle secrets
-Secrets should be handled securely at all times.
-- Secrets should not be passed as plain text in command line
-- Do not be persist secrets on the container labels or long lived permanent caches
-- Redact secrets to prevent them being written in plain text into logs and console output.

--- a/proposals/secrets-support.md
+++ b/proposals/secrets-support.md
@@ -66,6 +66,15 @@ Example secrets file in json format:
 ]
 ```
 
+Further simplified json kv pair format:
+```json
+{
+	"API_KEY": "adsjhsd6dfwdjfwde7edwfwedfdjedwf7wedfwe",
+	"NUGET_CONFIG": "<config>\n    <add key=\"dependencyVersion\" value=\"Highest\" />\n    <add key=\"http_proxy\" value=\"http://company-squid:3128@contoso.com\" />\n</config>",
+	"PASSWORD": "Simple Passwords"
+}
+```
+
 ### Using secrets in the CLI
 Today Codespaces as a consumer is leveraging `remoteEnv` to pass secrets into the CLI. So it is a basic requirement that secrets should be used and behave the same way as `remoteEnv` do.
 

--- a/proposals/secrets-support.md
+++ b/proposals/secrets-support.md
@@ -16,7 +16,7 @@ Today Codespaces pass secret variables as `remoteEnv` since there are no other m
 
 ## Proposal
 
-Following are the three main functional changes to the CLI to support this feature.
+A [supporting tool](https://containers.dev/supporting#tools) (ie, the [dev container CLI reference implementation](https://github.com/devcontainers/cli) should behave according to the following properties:
 
   1. Ability to pass secrets to commands
   2. Apply/use secrets similar to `remoteEnv`

--- a/proposals/secrets-support.md
+++ b/proposals/secrets-support.md
@@ -36,30 +36,3 @@ Using a file to pass in the secrets can be one of the simple approaches to adopt
 		"PASSWORD": "Simple Passwords"
 	}
 	```
-
-### Using secrets
-Today many consumers are leveraging `remoteEnv` to pass in secrets. So it is a basic requirement that secrets should be used and behave the same way as `remoteEnv` do.
-
-### Securely handle secrets
-Secrets should be handled securely at all times.
-- Secrets should not be exposed in plan text at rest and in transit.
-- Do not persist secrets on the container labels or long lived permanent caches
-- Redact/mask secrets before writing to logs and output.
-
-## Notes
-Notes on how this proposal may be adopted by the dev containers CLI (reference implementation).
-
-### Passing secrets to the commands
-Secrets should not be passed directly in the command line since that would risk it getting stored in command history. Best way to pass secrets would be through a json file, where in the file path is supplied in a command line argument named `--secrets-file`.
-The dev containers CLI may support a default json file path with respect to the .devcontainer root, which will be used if the user does not provide a path explicitly using `--secrets-file` argument.
-
-Secrets should be passed to the following dev containers CLI commands.
-
-#### **Phase 1**
- - up
- - run-user-commands
-
-`up`, `run-user-commands` will use the secrets for use cases like lifecycle hooks (similar to remoteEnv). We do not plan secrets support for `build` command since we do not have a demonstrated requirement, as well as to avoid potentially baking in the user secrets into the docker images.
-
-#### **Phase 2**
-In phase 2 the support for secrets can be expanded to additional commands such as `set-up` and `exec`.


### PR DESCRIPTION
Formal proposal based on https://github.com/devcontainers/spec/issues/219

This proposal do not change the devcontainers spec itself, rather it is a proposal on the implementation of secrets support in supporting tools such as the devcontainers CLI (which could serve as a potential reference implementation)