### PR TITLE
Set `source` property as not required for `Mount`

### DIFF
--- a/schemas/devContainer.base.schema.json
+++ b/schemas/devContainer.base.schema.json
@@ -688,7 +688,6 @@
 			},
 			"required": [
 				"type",
-				"source",
 				"target"
 			],
 			"additionalProperties": false

--- a/schemas/devContainerFeature.schema.json
+++ b/schemas/devContainerFeature.schema.json
@@ -322,7 +322,6 @@
       },
       "required": [
         "type",
-        "source",
         "target"
       ],
       "type": "object"


### PR DESCRIPTION
**Description**:

The `source` attribute could be omitted for the `mount` command. In this case, Docker uses anonymous volumes. We update the devcontainer CLI to support such a case, and we need to update schemas to set the `source` property as optional.

_Changelog_:

- The `source` property was removed from `required` array;


**Related changes**:

- https://github.com/devcontainers/cli/pull/537