### PR TITLE
[Docs] fixes broken link 

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -14,7 +14,7 @@ Here is a sample:
 |----------|------|-------------|
 | `image` | string | **Required** when [using an image](/docs/remote/create-dev-container.md#using-an-image-or-dockerfile). The name of an image in a container registry ([DockerHub](https://hub.docker.com), [GitHub Container Registry](https://docs.github.com/packages/guides/about-github-container-registry), [Azure Container Registry](https://azure.microsoft.com/services/container-registry/)) that VS Code and other `devcontainer.json` supporting services / tools should use to create the dev container. |
 
-- PRs to the [schema](https://github.com/microsoft/vscode/blob/main/extensions/configuration-editing/schemas/devContainer.vscode.schema.json), i.e code or shell scripts demonstrating approaches for implementation.
+- PRs to the [schema](https://github.com/devcontainers/spec/blob/main/schemas/devContainer.base.schema.json), i.e code or shell scripts demonstrating approaches for implementation.
 
 Once there is discussion on your proposal, please also open and link a PR to update the [devcontainer.json reference doc](https://github.com/microsoft/vscode-docs/blob/main/docs/remote/devcontainerjson-reference.md). When your proposal is merged, the docs will be kept up-to-date with the latest spec.
 

--- a/contributing.md
+++ b/contributing.md
@@ -14,7 +14,7 @@ Here is a sample:
 |----------|------|-------------|
 | `image` | string | **Required** when [using an image](/docs/remote/create-dev-container.md#using-an-image-or-dockerfile). The name of an image in a container registry ([DockerHub](https://hub.docker.com), [GitHub Container Registry](https://docs.github.com/packages/guides/about-github-container-registry), [Azure Container Registry](https://azure.microsoft.com/services/container-registry/)) that VS Code and other `devcontainer.json` supporting services / tools should use to create the dev container. |
 
-- PRs to the [schema](https://github.com/devcontainers/spec/blob/main/schemas/devContainer.base.schema.json), i.e code or shell scripts demonstrating approaches for implementation.
+- PRs to the [schema](https://github.com/microsoft/vscode/blob/main/extensions/configuration-editing/schemas/devContainer.vscode.schema.json), i.e code or shell scripts demonstrating approaches for implementation.
 
 Once there is discussion on your proposal, please also open and link a PR to update the [devcontainer.json reference doc](https://github.com/microsoft/vscode-docs/blob/main/docs/remote/devcontainerjson-reference.md). When your proposal is merged, the docs will be kept up-to-date with the latest spec.
 

--- a/contributing.md
+++ b/contributing.md
@@ -14,7 +14,7 @@ Here is a sample:
 |----------|------|-------------|
 | `image` | string | **Required** when [using an image](/docs/remote/create-dev-container.md#using-an-image-or-dockerfile). The name of an image in a container registry ([DockerHub](https://hub.docker.com), [GitHub Container Registry](https://docs.github.com/packages/guides/about-github-container-registry), [Azure Container Registry](https://azure.microsoft.com/services/container-registry/)) that VS Code and other `devcontainer.json` supporting services / tools should use to create the dev container. |
 
-- PRs to the [schema](https://github.com/microsoft/vscode/blob/main/extensions/configuration-editing/schemas/devContainer.schema.src.json), i.e code or shell scripts demonstrating approaches for implementation.
+- PRs to the [schema](https://github.com/devcontainers/spec/blob/main/schemas/devContainer.base.schema.json), i.e code or shell scripts demonstrating approaches for implementation.
 
 Once there is discussion on your proposal, please also open and link a PR to update the [devcontainer.json reference doc](https://github.com/microsoft/vscode-docs/blob/main/docs/remote/devcontainerjson-reference.md). When your proposal is merged, the docs will be kept up-to-date with the latest spec.
 

--- a/docs/specs/devcontainerjson-reference.md
+++ b/docs/specs/devcontainerjson-reference.md
@@ -161,7 +161,7 @@ Variables can be referenced in certain string values in `devcontainer.json` in t
 
 ## Schema
 
-You can see the VS Code implementation of the dev container schema [here](https://github.com/devcontainers/spec/blob/main/schemas/devContainer.base.schema.json).
+You can see the dev container schema [here](https://github.com/devcontainers/spec/blob/main/schemas/devContainer.base.schema.json).
 
 
 ## Publishing vs forwarding ports

--- a/docs/specs/devcontainerjson-reference.md
+++ b/docs/specs/devcontainerjson-reference.md
@@ -161,7 +161,7 @@ Variables can be referenced in certain string values in `devcontainer.json` in t
 
 ## Schema
 
-You can see the VS Code implementation of the dev container schema [here](https://github.com/devcontainers/spec/blob/main/schemas/devContainer.base.schema.json).
+You can see the VS Code implementation of the dev container schema [here](https://github.com/microsoft/vscode/blob/main/extensions/configuration-editing/schemas/devContainer.vscode.schema.json).
 
 
 ## Publishing vs forwarding ports

--- a/docs/specs/devcontainerjson-reference.md
+++ b/docs/specs/devcontainerjson-reference.md
@@ -161,7 +161,7 @@ Variables can be referenced in certain string values in `devcontainer.json` in t
 
 ## Schema
 
-You can see the VS Code implementation of the dev container schema [here](https://github.com/microsoft/vscode/blob/main/extensions/configuration-editing/schemas/devContainer.schema.src.json).
+You can see the VS Code implementation of the dev container schema [here](https://github.com/devcontainers/spec/blob/main/schemas/devContainer.base.schema.json).
 
 
 ## Publishing vs forwarding ports

--- a/docs/specs/devcontainerjson-reference.md
+++ b/docs/specs/devcontainerjson-reference.md
@@ -161,7 +161,7 @@ Variables can be referenced in certain string values in `devcontainer.json` in t
 
 ## Schema
 
-You can see the VS Code implementation of the dev container schema [here](https://github.com/microsoft/vscode/blob/main/extensions/configuration-editing/schemas/devContainer.vscode.schema.json).
+You can see the VS Code implementation of the dev container schema [here](https://github.com/devcontainers/spec/blob/main/schemas/devContainer.base.schema.json).
 
 
 ## Publishing vs forwarding ports


### PR DESCRIPTION
Hi,

i have noticed that the link to the schema which is referenced in [`contributing.md`](https://github.com/devcontainers/spec/blob/main/contributing.md?plain=1#L17) and [`devcontainerjson-reference.md`](https://github.com/devcontainers/spec/blob/main/docs/specs/devcontainerjson-reference.md?plain=1#L164) is broken. It links to a `devContainer.schema.src.json` file that no longer exists in the vscode repo (removed in this [PR](https://github.com/microsoft/vscode/pull/169857)).

I have adjusted the docs to link to the [`devContainer.base.schema.json`](https://github.com/devcontainers/spec/blob/main/schemas/devContainer.base.schema.json) which is found in this repo.

I hope this is correct. If not, sorry for any inconvenience.