### PR TITLE
fix schema link

### DIFF
--- a/schemas/devContainer.schema.json
+++ b/schemas/devContainer.schema.json
@@ -1,7 +1,7 @@
 {
     "allOf": [
         {
-            "$ref": "./devContainer.base.schema.json"
+            "$ref": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainer.base.schema.json"
         },
         {
             "$ref": "https://raw.githubusercontent.com/microsoft/vscode/main/extensions/configuration-editing/schemas/devContainer.codespaces.schema.json"


### PR DESCRIPTION
v8r linter needs to have the schema accessible, hence this way it will be forever accessible