### PR TITLE
Fix documentation markdown styling

### DIFF
--- a/docs/specs/devcontainer-reference.md
+++ b/docs/specs/devcontainer-reference.md
@@ -18,7 +18,7 @@ While the structure of this metadata is critical, it is also important to call o
 
 - .devcontainer/devcontainer.json
 - .devcontainer.json
-- .devcontainer/<folder>/devcontainer.json (where <folder> is a sub-folder, one level deep)
+- .devcontainer/`<folder>`/devcontainer.json (where `<folder>` is a sub-folder, one level deep)
 
 It is valid that these files may exist in more than one location, so consider providing a mechanism for users to select one when appropriate.
 


### PR DESCRIPTION
Found this issue while browsing the spec. Without proper styling, it is unable to be displayed in the browser.

This is what it currently looks like:

![image](https://github.com/devcontainers/spec/assets/28675546/8b70bfc7-4d19-45ff-aaba-11fd5a9d3df7)
