### PR TITLE
update templates-distribution to have working oras examples

### DIFF
--- a/docs/specs/devcontainer-templates-distribution.md
+++ b/docs/specs/devcontainer-templates-distribution.md
@@ -108,7 +108,7 @@ ARTIFACT_PATH=devcontainer-template-go.tgz
 for VERSION in 1  1.2  1.2.3  latest
 do
         oras push ${REGISTRY}/${NAMESPACE}/${TEMPLATE}:${VERSION} \
-                --manifest-config /dev/null:application/vnd.devcontainers \
+                --config /dev/null:application/vnd.devcontainers \
                         ./${ARTIFACT_PATH}:application/vnd.devcontainers.layer.v1+tar
 done
 
@@ -124,6 +124,6 @@ REGISTRY=ghcr.io
 NAMESPACE=devcontainers/templates
 
 oras push ${REGISTRY}/${NAMESPACE}:latest \
-        --manifest-config /dev/null:application/vnd.devcontainers \
+        --config /dev/null:application/vnd.devcontainers \
                             ./devcontainer-collection.json:application/vnd.devcontainers.collection.layer.v1+json
 ```


### PR DESCRIPTION
The push and pull examples do not work with the current cli.  It looks like the `--manifest-config` option was renamed to `--config` some time ago.