### PR TITLE
Add JSON schema for Development Container Template Metadata

### DIFF
--- a/schemas/devContainerTemplate.schema.json
+++ b/schemas/devContainerTemplate.schema.json
@@ -1,0 +1,182 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Development Container Template Metadata",
+  "description": "Development Container Template Metadata (devcontainer-template.json). See https://containers.dev/implementors/templates/ for more information.",
+  "definitions": {
+    "Template": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "$schema": {
+          "description": "The JSON schema of the `devcontainer-template.json` file.",
+          "type": "string",
+          "format": "uri"
+        },
+        "description": {
+          "description": "Description of the Template.",
+          "type": "string"
+        },
+        "documentationURL": {
+          "description": "Url that points to the documentation of the Template.",
+          "type": "string",
+          "format": "uri"
+        },
+        "id": {
+          "description": "ID of the Template. The id should be unique in the context of the repository/published package where the Template exists and must match the name of the directory where the devcontainer-template.json resides.",
+          "type": "string"
+        },
+        "keywords": {
+          "description": "List of strings relevant to a user that would search for this Template.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "licenseURL": {
+          "description": "Url that points to the license of the Template.",
+          "type": "string",
+          "format": "uri"
+        },
+        "name": {
+          "description": "Name of the Template.",
+          "type": "string"
+        },
+        "options": {
+          "description": "A map of options that the supporting tools should use to populate different configuration options for the Template.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Option"
+          }
+        },
+        "platforms": {
+          "description": "Languages and platforms supported by the Template.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "publisher": {
+          "description": "Name of the publisher/maintainer of the Template.",
+          "type": "string"
+        },
+        "version": {
+          "description": "The semantic version of the Template.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "version"
+      ]
+    },
+    "Option": {
+      "description": "An option that the supporting tools should use to populate different configuration options for the Template.",
+      "type": "object",
+      "properties": {
+        "default": {
+          "description": "Default value for the option.",
+          "type": [
+            "boolean",
+            "string"
+          ]
+        },
+        "description": {
+          "description": "Description for the option.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type of the option. Valid types are currently: boolean, string",
+          "type": "string",
+          "enum": [
+            "boolean",
+            "string"
+          ]
+        }
+      },
+      "required": [
+        "default",
+        "description",
+        "type"
+      ],
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "default": {
+              "type": "boolean"
+            },
+            "description": true,
+            "type": {
+              "type": "string",
+              "const": "boolean"
+            }
+          },
+          "required": [
+            "default",
+            "type"
+          ]
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "default": {
+              "type": "string"
+            },
+            "description": true,
+            "enum": true,
+            "proposals": true,
+            "type": {
+              "type": "string",
+              "const": "string"
+            }
+          },
+          "required": [
+            "default",
+            "type"
+          ],
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "enum": {
+                  "description": "A strict list of allowed string values. Free-form values are not allowed. Omit when using optionId.proposals.",
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [
+                "enum"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "proposals": {
+                  "description": "A list of suggested string values. Free-form values are allowed. Omit when using optionId.enum.",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [
+                "proposals"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "oneOf": [
+    {
+      "$ref": "#/definitions/Template"
+    }
+  ]
+}


### PR DESCRIPTION
I've made an attempt at creating the JSON schema for Template metadata which I requested in #349.

Some notes:

* It is patterned after `devContainerFeature.schema.json`, on the theory that Template metadata has more in common with Feature metadata than it does Development Container metadata.
* The spec doesn't indicate which properties are required, so:
    * For Templates, between how they are described to be used and the fact that `id`, `name`, and `version` are required for Feature metadata, I've assumed those same three properties are required for Template metadata.
    * For options, based on how they are described to be used, I've assumed that all properties are required (with the exception of `enum` and `proposals`; see the points below).
* Though the spec indicates that an option's `default` property may only be a string, I've assumed that it should instead be a boolean when the `type` property is `"boolean"`.
* With regards to the `enum` and `proposals` properties of options:
    * I've assumed that neither `enum` nor `proposals` are relevant to boolean options, so have forbidden them.
    * I've assumed that `enum` cannot be an empty array, on the theory that because free-form values are not allowed, it would make it impossible to set a valid value for that option.
        * I have *not* made the same assumption regarding `proposals`, as free-form values are allowed.
    * As a result of the preceding point, if `enum` is not present on an option, `proposals` **must** be, even if it is an empty array.
* I haven't placed any restrictions (e.g. via patterns) on Template IDs, Template versions, or option IDs, as the Feature schema also doesn't. However, these could easily be added.

Apologies for the verbose description; I'm only getting started with Development Containers and want to make sure that any mistakes I've made are easy to spot. 😅