### PR TITLE
fix: allow trialing comma in JSON schema

### DIFF
--- a/schemas/devContainer.base.schema.json
+++ b/schemas/devContainer.base.schema.json
@@ -2,7 +2,7 @@
 	"$schema": "https://json-schema.org/draft/2019-09/schema",
 	"description": "Defines a dev container",
 	"allowComments": true,
-	"allowTrailingCommas": false,
+	"allowTrailingCommas": true,
 	"definitions": {
 		"devContainerCommon": {
 			"type": "object",


### PR DESCRIPTION
[Sorry :pray: if this is not the right way to do this, I just got here when I was looking how to silence 'Trailing comma' warnings in VS Code when editing a `devcontainer.json` file]

Currently a `devcontainer.json` with trailing commas works.

Either the schema or implementation is wrong, since they don't match. Changing the schema is probably easier, since changing the implementation would probably break many devcontainers.