### PR TITLE
Fix note and tip blocks

### DIFF
--- a/docs/specs/devcontainer-features.md
+++ b/docs/specs/devcontainer-features.md
@@ -72,7 +72,7 @@ For each lifecycle hook (in [Feature installation order](https://containers.dev/
 
 If a Feature provides a given command with the [object syntax](/docs/specs/devcontainerjson-reference.md#formatting-string-vs-array-properties), all commands within that group are executed in parallel, but still blocking commands from subsequent Features and/or the `devcontainer.json`.
 
-> NOTE: These properties are stored within [image metadata](https://github.com/devcontainers/spec/blob/joshspicer/lifecycle_hook_feature_spec/docs/specs/devcontainer-reference.md#merge-logic).
+> **Note:** These properties are stored within [image metadata](https://github.com/devcontainers/spec/blob/joshspicer/lifecycle_hook_feature_spec/docs/specs/devcontainer-reference.md#merge-logic).
 
 ### The `options` property
 
@@ -190,7 +190,7 @@ Below is a valid `features` object provided as an example.
 }
 ```
 
-> Note: The `:latest` version annotation is added implicitly if omitted. To pin to a specific package version ([example](https://github.com/devcontainers/features/pkgs/container/features/go/versions)), append it to the end of the Feature.
+> **Note:** The `:latest` version annotation is added implicitly if omitted. To pin to a specific package version ([example](https://github.com/devcontainers/features/pkgs/container/features/go/versions)), append it to the end of the Feature.
 
 An option's value can be provided as either a `string` or `boolean`, and should match what is expected by the Feature in the `devcontainer-feature.json` file.
 

--- a/docs/specs/devcontainer-templates.md
+++ b/docs/specs/devcontainer-templates.md
@@ -65,7 +65,7 @@ The `options` property contains a map of option IDs and their related configurat
 | `optionId.enum` | array | A strict list of allowed string values. Free-form values are **not** allowed. Omit when using `optionId.proposals`. |
 | `optionId.default` | string | Default value for the option. |
 
-> `Note`: The `options` must be unique for every `devcontainer-template.json`
+> **Note:** The `options` must be unique for every `devcontainer-template.json`
 
 ### The `optionalPaths` property
 

--- a/docs/specs/features-contribute-lifecycle-scripts.md
+++ b/docs/specs/features-contribute-lifecycle-scripts.md
@@ -24,7 +24,7 @@ Note that `initializeCommand` is omitted, pending further discussions around a s
 
 As with all lifecycle hooks, commands are executed from the context (cwd) of the [project workspace folder](https://containers.dev/implementors/spec/#project-workspace-folder). 
 
-> NOTE: To use any assets (a script, etc...) embedded within a Feature in a lifecycle hook property, it is the Feature author's reponsibility to copy that assert to somewhere on the container where it will persist (outside of `/tmp`.) Implementations are not required to persist Feature install scripts beyond the initial build.
+> **Note:** To use any assets (a script, etc...) embedded within a Feature in a lifecycle hook property, it is the Feature author's reponsibility to copy that assert to somewhere on the container where it will persist (outside of `/tmp`.) Implementations are not required to persist Feature install scripts beyond the initial build.
 
 All other semantics match the existing [Lifecycle Scripts](https://containers.dev/implementors/json_reference/#lifecycle-scripts) and [lifecycle script parallel execution](https://containers.dev/implementors/spec/#parallel-exec) behavior exactly.
 

--- a/docs/specs/supporting-tools.md
+++ b/docs/specs/supporting-tools.md
@@ -83,7 +83,7 @@ A [codespace](https://docs.github.com/en/codespaces/overview) is a development e
 
 > **Tip:** If you've already built a codespace and connected to it, be sure to run **Codespaces: Rebuild Container** from the Command Palette (`kbstyle(F1)`) to pick up any changes you make.
 
-> **Tip** Codespaces implements an auto `workspaceFolder` mount in **Docker Compose** scenarios.
+> **Tip:** Codespaces implements an auto `workspaceFolder` mount in **Docker Compose** scenarios.
 
 #### Product specific properties
 GitHub Codespaces works with a growing number of tools and, where applicable, their `devcontainer.json` properties. For example, connecting the codespaces web editor or VS Code enables the use of [VS Code properties](#visual-studio-code).


### PR DESCRIPTION
Looking at all places, the general pattern in the repo is:

```
> **Note:** SENTENCE
```
...and

```
> **Tip:** SENTENCE
```