### PR TITLE
Fix incorrect heading size

### DIFF
--- a/docs/specs/devcontainer-features.md
+++ b/docs/specs/devcontainer-features.md
@@ -400,7 +400,7 @@ If a Feature is indicated in `overrideFeatureInstallOrder` but not a member of t
 > 
 > - If the [`devcontainer.json` contains an `overrideFeatureInstallOrder`](#the-overridefeatureinstallorder-property).
 > 
-> #### (3) Round-based sorting
+> ### (3) Round-based sorting
 > 
 > Perform a sort on the result of **(1)** in rounds. This sort will rearrange Features, producing a sorted list of Features to install.  The sort will be performed as follows: 
 > 


### PR DESCRIPTION
Steps **(1)** and **(2)** have 3 pounds, but **(3)** has 4:

* [(1) Build a dependency graph](https://github.com/devcontainers/spec/blob/9fb374c7f29b4e3aaf55e7df69ed7514d6189dcd/docs/specs/devcontainer-features.md?plain=1#L385)
* [(2) Assigning round priority](https://github.com/devcontainers/spec/blob/9fb374c7f29b4e3aaf55e7df69ed7514d6189dcd/docs/specs/devcontainer-features.md?plain=1#L393)