### PR TITLE
Fix paragraph continuation pattern

### DIFF
--- a/docs/specs/devcontainer-templates.md
+++ b/docs/specs/devcontainer-templates.md
@@ -163,7 +163,7 @@ Suppose the `java` Template has the following `options` parameters declared in t
 }
 ```
 
-and it has the following `.devcontainer/devcontainer.json` file:
+...and it has the following `.devcontainer/devcontainer.json` file:
 
 ```json
 {


### PR DESCRIPTION
When a paragraph is a continuation of its preceding paragraph, it starts with `...`. Examples:

* [Features distribution](https://github.com/devcontainers/spec/blob/9fb374c7f29b4e3aaf55e7df69ed7514d6189dcd/docs/specs/devcontainer-features-distribution.md?plain=1#L50)
* [Templates distribution](https://github.com/devcontainers/spec/blob/9fb374c7f29b4e3aaf55e7df69ed7514d6189dcd/docs/specs/devcontainer-templates-distribution.md?plain=1#L51)