### PR TITLE
Fix 'git' brand and trademark

### DIFF
--- a/docs/specs/devcontainer-features-distribution.md
+++ b/docs/specs/devcontainer-features-distribution.md
@@ -15,9 +15,9 @@ Goals include:
 
 ## Source code
 
-Features source code is stored in a git repository.
+Features source code is stored in a Git repository.
 
-For ease of authorship and maintenance, [1..n] features can share a single git repository. This set of features is referred to as a "collection," and will share the same [`devcontainer-collection.json`](#devcontainer-collection.json) file and "namespace" (eg. `<owner>/<repo>`).
+For ease of authorship and maintenance, [1..n] features can share a single Git repository. This set of features is referred to as a "collection," and will share the same [`devcontainer-collection.json`](#devcontainer-collection.json) file and "namespace" (eg. `<owner>/<repo>`).
 
 Source code for the set follows the example file structure below:
 
@@ -117,7 +117,7 @@ done
 
 ```
 
-The "namespace" is the globally identifiable name for the collection of Features. (eg: `owner/repo` for the source code's git repository).
+The "namespace" is the globally identifiable name for the collection of Features. (eg: `owner/repo` for the source code's Git repository).
 
 The auto-generated `devcontainer-collection.json` is pushed to the registry with the same `namespace` as above and no accompanying `feature` name. The collection file is always tagged as `latest`.
 

--- a/docs/specs/devcontainer-reference.md
+++ b/docs/specs/devcontainer-reference.md
@@ -283,4 +283,4 @@ Each entry in the `object` will be run in parallel during that lifecycle step.
 
 #### **Project Workspace Folder**
 
-The **project workspace folder** is where an implementing tool should begin to search for `devcontainer.json` files. If the target project on disk is using git, the **project workspace folder** is typically the root of the git repository. 
+The **project workspace folder** is where an implementing tool should begin to search for `devcontainer.json` files. If the target project on disk is using Git, the **project workspace folder** is typically the root of the Git repository. 

--- a/docs/specs/devcontainer-templates-distribution.md
+++ b/docs/specs/devcontainer-templates-distribution.md
@@ -11,11 +11,11 @@ Goals include:
 
 ## Source code
 
-A Template's source code is stored in a git repository.
+A Template's source code is stored in a Git repository.
 
-For ease of authorship and maintenance, [1..n] Templates can share a single git repository. This set of Templates is referred to as a "collection," and will share the same [`devcontainer-collection.json`](#devcontainer-collection.json) file and "namespace" (eg. `<owner>/<repo>`).
+For ease of authorship and maintenance, [1..n] Templates can share a single Git repository. This set of Templates is referred to as a "collection," and will share the same [`devcontainer-collection.json`](#devcontainer-collection.json) file and "namespace" (eg. `<owner>/<repo>`).
 
-> **Note:** Templates and [Features](./devcontainer-features.md) should be placed in different git repositories. 
+> **Note:** Templates and [Features](./devcontainer-features.md) should be placed in different Git repositories. 
 
 Source code for a set of Templates follows the example file structure below:
 
@@ -114,7 +114,7 @@ done
 
 ```
 
-The "namespace" is the globally identifiable name for the collection of Templates. (eg: `owner/repo` for the source code's git repository).
+The "namespace" is the globally identifiable name for the collection of Templates. (eg: `owner/repo` for the source code's Git repository).
 
 The auto-generated `devcontainer-collection.json` is pushed to the registry with the same `namespace` as above and no accompanying `template` name. The collection file is always tagged as `latest`.
 


### PR DESCRIPTION
**Heads-up:** Potentially a spicy topic (open to discussion and even rejection)

Although the [Git logo](https://git-scm.com/downloads/logos) is all lowercase, i.e. "**g**it", the [textual representation of the project](https://git-scm.com/about/trademark) is "**G**it".

When used as a general text, it should be used like this:

> Create a Git repository

When used as a CLI command, it should be used like this:

> Use the `git` command line

To see proper examples, search for `git` in the official [Git - Getting a Git Repository](https://git-scm.com/book/en/v2/Git-Basics-Getting-a-Git-Repository) document to see what I mean.

I understand that both "**g**it" and "**G**it" are generally used in online articles or product documentations. However, the usage here is an _expert-written formal spec and standard_. 

I believe it should reflect professionalism and not follow the general "what everyone else does" pattern, but again it's more of a personal opinion than right or wrong. So, up to the maintainer what to do with this PR...