### PR TITLE
Fix casing for 'unix'

### DIFF
--- a/docs/specs/devcontainer-features-distribution.md
+++ b/docs/specs/devcontainer-features-distribution.md
@@ -184,7 +184,7 @@ Additional constraints exists when including local Features in a project:
 
 * The local Feature's sub-folder **must** contain at least a `devcontainer-feature.json` file and `install.sh` entrypoint script, mirroring the [previously outlined file structure](#Source-code).
 
-The relative path is provided using unix-style path syntax (eg `./myFeature`) regardless of the host operating system.
+The relative path is provided using Unix-style path syntax (eg `./myFeature`) regardless of the host operating system.
 
 An example project is illustrated below:
 


### PR DESCRIPTION
Yet another PR similar to #615 

The trademark is registered as "UNIX®", but when referred as a generic name (to refer to the broader family of Linux, FreeBSD, OpenBSD, etc.), it's usually written as "Unix".

[Unix - Wikipedia](https://en.wikipedia.org/wiki/Unix)

⚖️ **Disclaimer:** I'm not a lawyer and it's not a legal advice. I'm just an engineer talking based on what I've seen/read around the Internet. It's up to the core maintainers to consider proper use and permissions of all trademarks. I take no responsibility for copyright infringements, trademark usage violations, or any financial/collateral damage (if any).