### PR TITLE
Add Zed to supporting tools

### DIFF
--- a/docs/specs/supporting-tools.md
+++ b/docs/specs/supporting-tools.md
@@ -38,6 +38,17 @@ Visual Studio added dev container support in Visual Studio 2022 17.4 for C++ pro
 
 You may learn more in the [announcement blog post](https://devblogs.microsoft.com/cppblog/dev-containers-for-c-in-visual-studio/).
 
+### Zed
+
+[Zed v0.218](https://zed.dev/releases/stable) and onward supports Dev Containers, but it is currently still in development with the following limitations:
+
+* Extensions: Zed does not yet manage extensions separately for container environments. The host's extensions are used as-is.
+* Port forwarding: Only the appPort field is supported. forwardPorts and other advanced port-forwarding features are not implemented.
+* Configuration changes: Updates to devcontainer.json do not trigger automatic rebuilds or reloads; containers must be manually restarted.
+
+For more information please see Zed's up-to-date [Dev Containers documentation](https://zed.dev/docs/dev-containers) and their [announcement blog post](https://zed.dev/blog/dev-containers).
+
+
 ## Tools
 
 ### Dev Container CLI


### PR DESCRIPTION
The [Zed code editor](https://zed.dev) recently announced [support for Dev Containers](https://zed.dev/blog/dev-containers) and said support is included in their current stable releases. 

This PR updates the supporting tools documentation (`docs/specs/supporting-tools.md`) to include Zed, noting [its known limitations](https://zed.dev/docs/dev-containers#known-limitations) due to "[it being] still in development."