### PR TITLE
Add $schema property for devcontainer-feature schema

### DIFF
--- a/schemas/devContainerFeature.schema.json
+++ b/schemas/devContainerFeature.schema.json
@@ -6,6 +6,11 @@
     "Feature": {
       "additionalProperties": false,
       "properties": {
+        "$schema": {
+          "type": "string",
+          "format": "uri",
+          "description": "The JSON schema of the `devcontainer-feature.json` file."
+        },
         "capAdd": {
           "description": "Passes docker capabilities to include when creating the dev container.",
           "examples": [


### PR DESCRIPTION
mirrored how the schema for `devcontainer.json` does this: https://github.com/devcontainers/spec/blob/c95ffeed1d059abfe9ffbe79762dc2fa4e7c2421/schemas/devContainer.base.schema.json#L10-L14

to avoid silly warnings like these:
<img width="351" height="47" alt="image" src="https://github.com/user-attachments/assets/596e67a8-be9a-4a60-babe-2e3ee5d3fdbf" />
